### PR TITLE
Fixed file handle leaks

### DIFF
--- a/ELFSharp/ELF.cs
+++ b/ELFSharp/ELF.cs
@@ -19,11 +19,13 @@ namespace ELFSharp
 			{
 				throw new ArgumentException("Given file is not proper ELF file.");
 			}
-            stream = GetNewStream();
-            ReadHeader();            
-            ReadStringTable();
-            ReadSections();
-            ReadSegmentHeaders();
+            using (stream = File.OpenRead(fileName))
+            {
+                ReadHeader();
+                ReadStringTable();
+                ReadSections();
+                ReadSegmentHeaders();
+            }
         }
 
         public Endianess Endianess { get; private set; }
@@ -182,16 +184,6 @@ namespace ELFSharp
             }
             return returned;
         }
-
-        private FileStream GetNewStream()
-        {
-            return new FileStream(
-                fileName,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.Read
-            );
-        }
      
         private void ReadSegmentHeaders()
         {
@@ -311,7 +303,7 @@ namespace ELFSharp
             }
             readerSource = () => new EndianBinaryReader(
                 converter,
-                GetNewStream()
+                File.OpenRead(fileName)
             );
             localReaderSource = () => new EndianBinaryReader(converter, new NonClosingStreamWrapper(stream));
             ReadFields();

--- a/ELFSharp/ELFReader.cs
+++ b/ELFSharp/ELFReader.cs
@@ -38,8 +38,9 @@ namespace ELFSharp
 			{
 				return Class.NotELF;
 			}
-			using(var reader = new BinaryReader(File.OpenRead(fileName)))
+			using(var stream = File.OpenRead(fileName))
 			{
+				var reader = new BinaryReader(stream);
 				var magic = reader.ReadBytes(4);
 				for(var i = 0; i < 4; i++)
 				{

--- a/ELFSharp/Sections/NoteData.cs
+++ b/ELFSharp/Sections/NoteData.cs
@@ -16,17 +16,19 @@ namespace ELFSharp.Sections
         
         internal NoteData(Class elfClass, long sectionOffset, Func<EndianBinaryReader> readerSource)
         {
-            reader = readerSource();
-            reader.BaseStream.Seek(sectionOffset, SeekOrigin.Begin);
-            var nameSize = ReadSize();
-            var descriptionSize = ReadSize();
-            Type = ReadField();
-            int remainder;
-            var fields = Math.DivRem(nameSize, FieldSize, out remainder);
-            var alignedNameSize = FieldSize*(remainder > 0 ? fields + 1 : fields);
-            var name = reader.ReadBytesOrThrow(alignedNameSize);
-            Name = Encoding.ASCII.GetString(name, 0, nameSize - 1); // minus one to omit terminating NUL
-            Description = reader.ReadBytesOrThrow((int)descriptionSize - 1);
+            using (reader = readerSource())
+            {
+                reader.BaseStream.Seek(sectionOffset, SeekOrigin.Begin);
+                var nameSize = ReadSize();
+                var descriptionSize = ReadSize();
+                Type = ReadField();
+                int remainder;
+                var fields = Math.DivRem(nameSize, FieldSize, out remainder);
+                var alignedNameSize = FieldSize * (remainder > 0 ? fields + 1 : fields);
+                var name = reader.ReadBytesOrThrow(alignedNameSize);
+                Name = Encoding.ASCII.GetString(name, 0, nameSize - 1); // minus one to omit terminating NUL
+                Description = reader.ReadBytesOrThrow((int)descriptionSize - 1);
+            }
         }
         
         private int ReadSize()


### PR DESCRIPTION
After parsing an ELF file a few file handles are still open. This can be reproduced by trying to delete a file right after running ElfLoader.TryLoad(). This patch adds the missing using() Blocks.
