### PR TITLE
Added .NET 2.0 version (with LinqBridge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 *.userprefs
 test-results/
+/packages/*/

--- a/ELFSharp.sln
+++ b/ELFSharp.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ELFSharp", "ELFSharp\ELFSharp.csproj", "{CF944E09-7C14-433C-A185-161848E989B3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ELFSharp.LinqBridge", "ELFSharp\ELFSharp.LinqBridge.csproj", "{6169D4ED-92C8-469C-ABF4-FF0FA29D557C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,6 +15,10 @@ Global
 		{CF944E09-7C14-433C-A185-161848E989B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF944E09-7C14-433C-A185-161848E989B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF944E09-7C14-433C-A185-161848E989B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6169D4ED-92C8-469C-ABF4-FF0FA29D557C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6169D4ED-92C8-469C-ABF4-FF0FA29D557C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6169D4ED-92C8-469C-ABF4-FF0FA29D557C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6169D4ED-92C8-469C-ABF4-FF0FA29D557C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = ELFSharp\ELFSharp.csproj

--- a/ELFSharp/ELF/ELF.cs
+++ b/ELFSharp/ELF/ELF.cs
@@ -60,7 +60,7 @@ namespace ELFSharp.ELF
 
         IEnumerable<ISegment> IELF.Segments
         {
-            get { return Segments; }
+            get { return Segments.Cast<ISegment>(); }
         }
 
         public IStringTable SectionsStringTable { get; private set; }
@@ -87,7 +87,7 @@ namespace ELFSharp.ELF
         {
             get
             {
-                return Sections;
+                return Sections.Cast<ISection>();
             }
         }
 

--- a/ELFSharp/ELF/Sections/SymbolTable.cs
+++ b/ELFSharp/ELF/Sections/SymbolTable.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using MiscUtil.IO;
 using System.Collections.ObjectModel;
 
@@ -21,7 +22,7 @@ namespace ELFSharp.ELF.Sections
 
         IEnumerable<ISymbolEntry> ISymbolTable.Entries
         {
-            get { return Entries; }
+            get { return Entries.Cast<ISymbolEntry>(); }
         }
 
         private void ReadSymbols()

--- a/ELFSharp/ELFSharp.LinqBridge.csproj
+++ b/ELFSharp/ELFSharp.LinqBridge.csproj
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{6169D4ED-92C8-469C-ABF4-FF0FA29D557C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ELFSharp</RootNamespace>
+    <AssemblyName>ELFSharp</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <BaseIntermediateOutputPath>obj\LinqBridge\</BaseIntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\LinqBridge\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\LinqBridge\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="LinqBridge, Version=1.3.0.0, Culture=neutral, PublicKeyToken=c2b14eb747628076, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\LinqBridge.1.3.0\lib\net20\LinqBridge.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MiscUtil\BigEndianBitConverter.cs" />
+    <Compile Include="MiscUtil\EndianBinaryReader.cs" />
+    <Compile Include="MiscUtil\EndianBinaryWriter.cs" />
+    <Compile Include="MiscUtil\EndianBitConverter.cs" />
+    <Compile Include="MiscUtil\Endianness.cs" />
+    <Compile Include="MiscUtil\LittleEndianBitConverter.cs" />
+    <Compile Include="MiscUtil\NonClosingStreamWrapper.cs" />
+    <Compile Include="MiscUtil\Streams.cs" />
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="ELF\Consts.cs" />
+    <Compile Include="ELF\Class.cs" />
+    <Compile Include="ELF\ELF.cs" />
+    <Compile Include="ELF\ELFReader.cs" />
+    <Compile Include="ELF\Endianess.cs" />
+    <Compile Include="ELF\FileType.cs" />
+    <Compile Include="ELF\IELF.cs" />
+    <Compile Include="ELF\Machine.cs" />
+    <Compile Include="ELF\Utilities.cs" />
+    <Compile Include="ELF\Sections\INoteSection.cs" />
+    <Compile Include="ELF\Sections\IProgBitsSection.cs" />
+    <Compile Include="ELF\Sections\ISection.cs" />
+    <Compile Include="ELF\Sections\IStringTable.cs" />
+    <Compile Include="ELF\Sections\ISymbolEntry.cs" />
+    <Compile Include="ELF\Sections\ISymbolTable.cs" />
+    <Compile Include="ELF\Sections\NoteData.cs" />
+    <Compile Include="ELF\Sections\NoteSection.cs" />
+    <Compile Include="ELF\Sections\ProgBitsSection.cs" />
+    <Compile Include="ELF\Sections\Section.cs" />
+    <Compile Include="ELF\Sections\SectionFlags.cs" />
+    <Compile Include="ELF\Sections\SectionHeader.cs" />
+    <Compile Include="ELF\Sections\SectionType.cs" />
+    <Compile Include="ELF\Sections\SpecialSectionIndex.cs" />
+    <Compile Include="ELF\Sections\SpecialSectionType.cs" />
+    <Compile Include="ELF\Sections\StringTable.cs" />
+    <Compile Include="ELF\Sections\SymbolBinding.cs" />
+    <Compile Include="ELF\Sections\SymbolEntry.cs" />
+    <Compile Include="ELF\Sections\SymbolTable.cs" />
+    <Compile Include="ELF\Sections\SymbolType.cs" />
+    <Compile Include="ELF\Segments\ISegment.cs" />
+    <Compile Include="ELF\Segments\Segment.cs" />
+    <Compile Include="ELF\Segments\SegmentFlags.cs" />
+    <Compile Include="ELF\Segments\SegmentType.cs" />
+    <Compile Include="UImage\UImage.cs" />
+    <Compile Include="UImage\CompressionType.cs" />
+    <Compile Include="UImage\UImageReader.cs" />
+    <Compile Include="UImage\UImageResult.cs" />
+    <Compile Include="UImage\ImageType.cs" />
+    <Compile Include="UImage\ImageDataResult.cs" />
+    <Compile Include="UImage\OS.cs" />
+    <Compile Include="UImage\Architecture.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <DotNetNamingPolicy DirectoryNamespaceAssociation="PrefixedHierarchical" ResourceNamePolicy="FileName" />
+          <TextStylePolicy FileWidth="120" NoTabsAfterNonTabs="True" EolMarker="Unix" inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/x-csharp" />
+          <CSharpFormattingPolicy AnonymousMethodBraceStyle="NextLine" PropertyBraceStyle="NextLine" PropertyGetBraceStyle="NextLine" PropertySetBraceStyle="NextLine" EventBraceStyle="NextLine" EventAddBraceStyle="NextLine" StatementBraceStyle="NextLine" ElseNewLinePlacement="NewLine" CatchNewLinePlacement="NewLine" FinallyNewLinePlacement="NewLine" WhileNewLinePlacement="NewLine" BeforeMethodDeclarationParentheses="False" BeforeMethodCallParentheses="False" BeforeConstructorDeclarationParentheses="False" BeforeIndexerDeclarationBracket="False" BeforeDelegateDeclarationParentheses="False" AfterDelegateDeclarationParameterComma="True" NewParentheses="False" IfParentheses="False" WhileParentheses="False" ForParentheses="False" ForeachParentheses="False" CatchParentheses="False" SwitchParentheses="False" LockParentheses="False" UsingParentheses="False" SpacesBeforeBrackets="False" inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp" />
+          <TextStylePolicy FileWidth="120" NoTabsAfterNonTabs="True" EolMarker="Unix" inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/plain" />
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
+</Project>

--- a/ELFSharp/MiscUtil/Streams.cs
+++ b/ELFSharp/MiscUtil/Streams.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+
+namespace MiscUtil.IO
+{
+    public static class Streams
+    {
+        /// <summary>
+        /// Copies the content of one stream to another in buffer-sized steps.
+        /// </summary>
+        /// <param name="source">The source stream to copy from.</param>
+        /// <param name="destination">The destination stream to copy to.</param>
+        /// <param name="bufferSize">The size of the buffer to use for copying in bytes.</param>
+        /// <remarks>Will try to <see cref="Stream.Seek"/> to the start of <paramref name="source"/>.</remarks>
+        public static void CopyTo(this Stream source, Stream destination, long bufferSize)
+        {
+            #region Sanity checks
+            if (source == null) throw new ArgumentNullException("source");
+            if (destination == null) throw new ArgumentNullException("destination");
+            #endregion
+
+            var buffer = new byte[bufferSize];
+            int read;
+
+            if (source.CanSeek) source.Position = 0;
+
+            do
+            {
+                read = source.Read(buffer, 0, buffer.Length);
+                destination.Write(buffer, 0, read);
+            } while (read != 0);
+
+            if (destination.CanSeek) destination.Position = 0;
+        }
+
+        /// <summary>
+        /// Copies the content of one stream to another in one go.
+        /// </summary>
+        /// <param name="source">The source stream to copy from.</param>
+        /// <param name="destination">The destination stream to copy to.</param>
+        public static void CopyTo(this Stream source, Stream destination)
+        {
+            #region Sanity checks
+            if (source == null) throw new ArgumentNullException("source");
+            if (destination == null) throw new ArgumentNullException("destination");
+            #endregion
+
+            source.CopyTo(destination, 4096);
+        }
+    }
+}

--- a/ELFSharp/UImage/UImage.cs
+++ b/ELFSharp/UImage/UImage.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Linq;
 using System.IO.Compression;
+using MiscUtil.IO;
 
 namespace ELFSharp.UImage
 {

--- a/ELFSharp/packages.config
+++ b/ELFSharp/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LinqBridge" version="1.3.0" targetFramework="net20" />
+</packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<repositories>
+  <repository path="..\ELFSharp\packages.config" />
+</repositories>


### PR DESCRIPTION
I use ElfSharp in [Zero Install](https://github.com/0install/0install-win). To ensure it runs out-of-the-box without additional dependency installations on most Windows boxes it still targets .NET 2.0.

I added an additional project file to ElfSharp that targets .NET 2.0. In order to replace the missing LINQ functionality I used [LinqBridge](https://code.google.com/p/linqbridge/). The other compatibility changes were rather minor.