### PR TITLE
Implemented TryGetSection + minor changes.

### DIFF
--- a/ELFSharp/ELF/IELF.cs
+++ b/ELFSharp/ELF/IELF.cs
@@ -17,7 +17,9 @@ namespace ELFSharp.ELF
         IStringTable SectionsStringTable { get; }
         IEnumerable<ISection> Sections { get; }
         IEnumerable<T> GetSections<T>() where T : ISection;
+        bool TryGetSection(string name, out ISection section);
         ISection GetSection(string name);
+        bool TryGetSection(int index, out ISection section);
         ISection GetSection(int index);
     }
 }


### PR DESCRIPTION
Added `TryGetSection` methods to `Elf` and `IELF` classes. Reimplemented
associated `Get` methods to use TryGets.

Defined magic index with a meaninigful name private constant.

Renamed template parameter in `GetSections` from `S` to `TSections`.
