### PR TITLE
Use UTF-8 to decode strings everywhere (and fixed locale-dependent unit tests)

### DIFF
--- a/ELFSharp/ELF/Sections/NoteData.cs
+++ b/ELFSharp/ELF/Sections/NoteData.cs
@@ -26,7 +26,7 @@ namespace ELFSharp.ELF.Sections
                 var fields = Math.DivRem(nameSize, FieldSize, out remainder);
                 var alignedNameSize = FieldSize * (remainder > 0 ? fields + 1 : fields);
                 var name = reader.ReadBytesOrThrow(alignedNameSize);
-                Name = Encoding.ASCII.GetString(name, 0, nameSize - 1); // minus one to omit terminating NUL
+                Name = Encoding.UTF8.GetString(name, 0, nameSize - 1); // minus one to omit terminating NUL
                 Description = reader.ReadBytesOrThrow((int)descriptionSize - 1);
             }
             reader = null;

--- a/ELFSharp/UImage/UImage.cs
+++ b/ELFSharp/UImage/UImage.cs
@@ -24,7 +24,7 @@ namespace ELFSharp.UImage
 				Type = (ImageType)reader.ReadByte();
 				Compression = (CompressionType)reader.ReadByte();
 				var nameAsBytes = reader.ReadBytes(32);
-				Name = Encoding.ASCII.GetString(nameAsBytes.Reverse().SkipWhile(x => x == 0).Reverse().ToArray());
+				Name = Encoding.UTF8.GetString(nameAsBytes.Reverse().SkipWhile(x => x == 0).Reverse().ToArray());
 				image = reader.ReadBytes((int)Size);
 			}
 		}

--- a/Tests/ELF/WebTests.cs
+++ b/Tests/ELF/WebTests.cs
@@ -50,7 +50,7 @@ namespace Tests.ELF
 .shstrtab: StringTable, load @0x0, 264 bytes long
 .symtab: SymbolTable, load @0x0, 1536 bytes long
 .strtab: StringTable, load @0x0, 566 bytes long";
-			var expectedOutputAsLines = expectedOutput.Split(new [] { Environment.NewLine }, StringSplitOptions.None);
+			var expectedOutputAsLines = expectedOutput.Split(new [] { "\n", "\r\n" }, StringSplitOptions.None);
 			CollectionAssert.AreEqual(expectedOutputAsLines, output);
 		}
 
@@ -78,7 +78,7 @@ __libc_csu_init
 _start
 main
 _init";
-			var expectedOutputAsLines = expectedOutput.Split(new [] { Environment.NewLine }, StringSplitOptions.None);
+			var expectedOutputAsLines = expectedOutput.Split(new [] { "\n", "\r\n" }, StringSplitOptions.None);
 			CollectionAssert.AreEqual(expectedOutputAsLines, output);
 		}
 

--- a/Tests/UImage/SimpleTests.cs
+++ b/Tests/UImage/SimpleTests.cs
@@ -39,7 +39,7 @@ namespace Tests.UImage
 		public void ShouldProperlyReadTimestamp()
 		{
 			var uImage = UImageReader.Load(Utilities.GetBinaryLocation("uImage-panda"));
-			Assert.AreEqual(new DateTime(2012, 4, 10, 21, 11, 06), uImage.Timestamp);
+			Assert.AreEqual(new DateTime(2012, 4, 10, 19, 11, 06, DateTimeKind.Utc).ToLocalTime(), uImage.Timestamp);
 		}
 
 		[Test]


### PR DESCRIPTION
I've changed the StringTable to use UTF-8 to decode strings, instead of the previous ISO-8859-1 decoding (via casting bytes to chars). While no string encoding is mentioned in the ELF specification, it seems that the de-facto standard, like for much else in the Linux-y world, is UTF-8 (e.g. this is what clang produces).

The StringTable is now also populated lazily, and reads the bytes (once) in a block instead of one at a time. This should improve performance.

Also, some of the unit tests were failing locally since they were dependent on the environment of the user running the tests -- one of them depended on the current timezone, and two others depended on `Environment.NewLine` being `"\n"`. I fixed that too (all the tests pass for me now).

I would be most grateful if you could accept these patches into the master, and in particular update the NuGet.

Finally, thanks for writing this library! It's extremely useful :-)