### PR TITLE
Fixed overflow potential on larger ELF files

### DIFF
--- a/ELFSharp/ELF/Sections/SectionHeader.cs
+++ b/ELFSharp/ELF/Sections/SectionHeader.cs
@@ -57,7 +57,7 @@ namespace ELFSharp.ELF.Sections
 
         private long ReadOffset()
         {
-            return elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadInt64();
+            return elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadUInt64();
         }
 
         private readonly SimpleEndianessAwareReader reader;


### PR DESCRIPTION
Had a 400MB ELF file cause an overflow in this part of the file load process.

Hope this helps, lots of love!

.fox