### PR TITLE
Ignore nonconforming note section data

### DIFF
--- a/ELFSharp/ELF/Sections/NoteData.cs
+++ b/ELFSharp/ELF/Sections/NoteData.cs
@@ -14,10 +14,11 @@ namespace ELFSharp.ELF.Sections
 
         internal ulong Type { get; private set; }
         
-        internal NoteData(Class elfClass, ulong sectionOffset, Func<SimpleEndianessAwareReader> readerSource)
+        internal NoteData(Class elfClass, ulong sectionOffset, ulong sectionSize, Func<SimpleEndianessAwareReader> readerSource)
         {
             using(reader = readerSource())
             {
+                var sectionEnd = (long)(sectionOffset + sectionSize);
                 reader.BaseStream.Seek((long)sectionOffset, SeekOrigin.Begin);
                 var nameSize = ReadSize();
                 var descriptionSize = ReadSize();
@@ -25,12 +26,23 @@ namespace ELFSharp.ELF.Sections
                 int remainder;
                 var fields = Math.DivRem(nameSize, FieldSize, out remainder);
                 var alignedNameSize = FieldSize * (remainder > 0 ? fields + 1 : fields);
-                var name = reader.ReadBytes(alignedNameSize);
-                if(nameSize > 0)
+
+                // We've encountered binaries where nameSize and descriptionSize are
+                // invalid (i.e. significantly larger than the size of the binary itself).
+                // To avoid throwing on such binaries, we only read in name and description
+                // if the sizes are within range of the containing section.
+                if (reader.BaseStream.Position + alignedNameSize <= sectionEnd)
                 {
-                    Name = Encoding.UTF8.GetString(name, 0, nameSize - 1); // minus one to omit terminating NUL
+                    var name = reader.ReadBytes(alignedNameSize);
+                    if (nameSize > 0)
+                    {
+                        Name = Encoding.UTF8.GetString(name, 0, nameSize - 1); // minus one to omit terminating NUL
+                    }
+                    if (reader.BaseStream.Position + descriptionSize <= sectionEnd)
+                    {
+                        Description = descriptionSize > 0 ? reader.ReadBytes(descriptionSize) : new byte[0];
+                    }
                 }
-                Description = descriptionSize > 0 ? reader.ReadBytes(descriptionSize) : new byte[0];
             }
             reader = null;
         }

--- a/ELFSharp/ELF/Sections/NoteSection.cs
+++ b/ELFSharp/ELF/Sections/NoteSection.cs
@@ -37,7 +37,7 @@ namespace ELFSharp.ELF.Sections
          
         internal NoteSection(SectionHeader header, Class elfClass, Func<SimpleEndianessAwareReader> readerSource) : base(header, readerSource)
         {
-            data = new NoteData(elfClass, header.Offset, readerSource);
+            data = new NoteData(elfClass, header.Offset, header.Size, readerSource);
         }
         
         private readonly NoteData data;

--- a/ELFSharp/ELFSharp.csproj
+++ b/ELFSharp/ELFSharp.csproj
@@ -4,19 +4,19 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sgKey.snk</AssemblyOriginatorKeyFile>
-    <InformationalVersion>2.1.1</InformationalVersion>
-    <PackageVersion>2.1.1</PackageVersion>
-    <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox</Authors>
+    <InformationalVersion>2.2.0</InformationalVersion>
+    <PackageVersion>2.2.0</PackageVersion>
+    <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox, Reuben Olinsky</Authors>
     <Owners>Konrad Kruczyński</Owners>
     <PackageProjectUrl>http://elfsharp.hellsgate.pl/</PackageProjectUrl>
-    <PackageReleaseNotes>Fixed returned content of segment when memory size is greater than file size. Should return zeroes at the end of the array.</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated parsing of note sections to silently ignore sections that do not match the expected format.</PackageReleaseNotes>
     <Summary>C# library for reading binary ELF, UImage, Mach-O files</Summary>
     <PackageTags>ELF UImage Mach-O</PackageTags>
     <Title>ELFSharp</Title>
     <Description>C# library for reading binary ELF, UImage, Mach-O files</Description>
     <PackageId>ELFSharp</PackageId>
     <Version>2.0</Version>
-    <FileVersion>2.1.1.0</FileVersion>
+    <FileVersion>2.2.0.0</FileVersion>
     <PackageIconUrl>http://elfsharp.hellsgate.pl/favicon.ico</PackageIconUrl>
   </PropertyGroup>
 </Project>

--- a/README
+++ b/README
@@ -10,6 +10,7 @@ Other contributors (in the order of the first contribution)
 * Frederik Carlier
 * Everett Maus
 * Fox
+* Reuben Olinsky
 
 You can find license in the LICENSE file.
 

--- a/Tests/Binaries/custom-note
+++ b/Tests/Binaries/custom-note
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcc1b21a1449186dbed4847e61dcc61d55f067a5d25633006e9d490713dcf913
+size 8296

--- a/Tests/ELF/NoteSectionTests.cs
+++ b/Tests/ELF/NoteSectionTests.cs
@@ -38,6 +38,19 @@ namespace Tests.ELF
             var noteSection = (NoteSection<ulong>)elf.GetSection(".note.ABI-tag");
             Assert.AreEqual(1, noteSection.NoteType);
         }
+
+        [Test]
+        public void ShouldNotThrowOnCustomNote()
+        {
+            // Not all notes conform to the expected format that the NoteSection
+            // class uses; this test validates that we can successfully parse a
+            // binary containing such a section and retrieve the note, all without
+            // throwing an exception.
+            const string sectionName = ".note.custom";
+            var elf = ELFReader.Load<uint>(Utilities.GetBinary("custom-note"));
+            var noteSection = (NoteSection<uint>)elf.GetSection(sectionName);
+            Assert.AreEqual(sectionName, noteSection.Name);
+        }
     }
 }
 


### PR DESCRIPTION
I've come across binaries whose note sections contain data that doesn't match the format expected by ElfSharp.  This change ignores such data, rather than throwing on parse of the binary.

Any and all feedback very much welcome -- in particular, I wasn't sure if there was a recommended way to non-fatally warn or otherwise log information about the unexpected sizes.