### PR TITLE
ELFReader overloads for Stream.

### DIFF
--- a/ELFSharp/ELF/ELFReader.cs
+++ b/ELFSharp/ELF/ELFReader.cs
@@ -1,28 +1,35 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 
 namespace ELFSharp.ELF
 {
 	public static class ELFReader
 	{
-		public static IELF Load(string fileName)
+        public static IELF Load(Stream stream, bool shouldOwnStream)
 		{
-            if(!TryLoad(fileName, out IELF elf))
+            if(!TryLoad(stream, shouldOwnStream, out IELF elf))
             {
-                throw new ArgumentException("Given file is not proper ELF file.");
+                throw new ArgumentException(NotELFMessage);
             }
+
             return elf;
 		}
 
-		public static bool TryLoad(string fileName, out IELF elf)
+        public static IELF Load(string fileName)
+        {
+			return Load(File.OpenRead(fileName), true);
+        }
+
+		public static bool TryLoad(Stream stream, bool shouldOwnStream, out IELF elf)
 		{
-			switch(CheckELFType(fileName))
+            switch(CheckELFType(stream))
 			{
 			case Class.Bit32:
-				elf = new ELF<uint>(fileName);
+				elf = new ELF<uint>(stream, shouldOwnStream);
 				return true;
 			case Class.Bit64:
-				elf = new ELF<ulong>(fileName);
+				elf = new ELF<ulong>(stream, shouldOwnStream);
 				return true;
 			default:
 				elf = null;
@@ -30,14 +37,21 @@ namespace ELFSharp.ELF
 			}
 		}
 
-		public static Class CheckELFType(string fileName)
+        public static bool TryLoad(string fileName, out IELF elf)
+        {
+			return TryLoad(File.OpenRead(fileName), true, out elf);
+        }
+
+		public static Class CheckELFType(Stream stream)
 		{
-			var size = new FileInfo(fileName).Length;
-			if(size < Consts.MinimalELFSize)
+			var currentStreamPosition = stream.Position;
+
+			if(stream.Length < Consts.MinimalELFSize)
 			{
 				return Class.NotELF;
 			}
-			using(var reader = new BinaryReader(File.OpenRead(fileName)))
+
+			using(var reader = new BinaryReader(stream, Encoding.UTF8, true))
 			{
 				var magic = reader.ReadBytes(4);
 				for(var i = 0; i < 4; i++)
@@ -48,22 +62,41 @@ namespace ELFSharp.ELF
 					}
 				}
 				var value = reader.ReadByte();
+				stream.Position = currentStreamPosition;
 				return value == 1 ? Class.Bit32 : Class.Bit64;
 			}
 		}
+
+        public static Class CheckELFType(string fileName)
+        {
+            using(var stream = File.OpenRead(fileName))
+            {
+				return CheckELFType(stream);
+            }
+        }
         
-		public static ELF<T> Load<T>(string fileName) where T : struct
+		public static ELF<T> Load<T>(Stream stream, bool shouldOwnStream) where T : struct
 		{
-			return new ELF<T>(fileName);
+			if(CheckELFType(stream) == Class.NotELF)
+			{
+				throw new ArgumentException(NotELFMessage);
+			}
+
+			return new ELF<T>(stream, shouldOwnStream);
 		}
 
-		public static bool TryLoad<T>(string fileName, out ELF<T> elf) where T : struct
+        public static ELF<T> Load<T>(string fileName) where T : struct
+        {
+			return Load<T>(File.OpenRead(fileName), true);
+        }
+
+		public static bool TryLoad<T>(Stream stream, bool shouldOwnStream, out ELF<T> elf) where T : struct
 		{
-			switch(CheckELFType(fileName))
+			switch(CheckELFType(stream))
 			{
 			case Class.Bit32:
 			case Class.Bit64:
-				elf = new ELF<T>(fileName);
+				elf = new ELF<T>(stream, shouldOwnStream);
 				return true;
 			default:
 				elf = null;
@@ -71,12 +104,19 @@ namespace ELFSharp.ELF
 			}
 		}
 
-		private static readonly byte[] Magic = {
+        public static bool TryLoad<T>(string fileName, out ELF<T> elf) where T : struct
+        {
+			return TryLoad<T>(File.OpenRead(fileName), true, out elf);
+        }
+
+		private static readonly byte[] Magic =
+        {
 			0x7F,
 			0x45,
 			0x4C,
 			0x46
 		}; // 0x7F 'E' 'L' 'F'
-        
+
+		private const string NotELFMessage = "Given stream is not a proper ELF file.";
 	}
 }

--- a/ELFSharp/ELF/Sections/NoteData.cs
+++ b/ELFSharp/ELF/Sections/NoteData.cs
@@ -14,37 +14,34 @@ namespace ELFSharp.ELF.Sections
 
         internal ulong Type { get; private set; }
         
-        internal NoteData(Class elfClass, ulong sectionOffset, ulong sectionSize, Func<SimpleEndianessAwareReader> readerSource)
+        internal NoteData(ulong sectionOffset, ulong sectionSize, SimpleEndianessAwareReader reader)
         {
-            using(reader = readerSource())
-            {
-                var sectionEnd = (long)(sectionOffset + sectionSize);
-                reader.BaseStream.Seek((long)sectionOffset, SeekOrigin.Begin);
-                var nameSize = ReadSize();
-                var descriptionSize = ReadSize();
-                Type = ReadField();
-                int remainder;
-                var fields = Math.DivRem(nameSize, FieldSize, out remainder);
-                var alignedNameSize = FieldSize * (remainder > 0 ? fields + 1 : fields);
+            this.reader = reader;
+            var sectionEnd = (long)(sectionOffset + sectionSize);
+            reader.BaseStream.Seek((long)sectionOffset, SeekOrigin.Begin);
+            var nameSize = ReadSize();
+            var descriptionSize = ReadSize();
+            Type = ReadField();
+            int remainder;
+            var fields = Math.DivRem(nameSize, FieldSize, out remainder);
+            var alignedNameSize = FieldSize * (remainder > 0 ? fields + 1 : fields);
 
-                // We've encountered binaries where nameSize and descriptionSize are
-                // invalid (i.e. significantly larger than the size of the binary itself).
-                // To avoid throwing on such binaries, we only read in name and description
-                // if the sizes are within range of the containing section.
-                if (reader.BaseStream.Position + alignedNameSize <= sectionEnd)
+            // We encountered binaries where nameSize and descriptionSize are
+            // invalid (i.e. significantly larger than the size of the binary itself).
+            // To avoid throwing on such binaries, we only read in name and description
+            // if the sizes are within range of the containing section.
+            if (reader.BaseStream.Position + alignedNameSize <= sectionEnd)
+            {
+                var name = reader.ReadBytes(alignedNameSize);
+                if (nameSize > 0)
                 {
-                    var name = reader.ReadBytes(alignedNameSize);
-                    if (nameSize > 0)
-                    {
-                        Name = Encoding.UTF8.GetString(name, 0, nameSize - 1); // minus one to omit terminating NUL
-                    }
-                    if (reader.BaseStream.Position + descriptionSize <= sectionEnd)
-                    {
-                        Description = descriptionSize > 0 ? reader.ReadBytes(descriptionSize) : new byte[0];
-                    }
+                    Name = Encoding.UTF8.GetString(name, 0, nameSize - 1); // minus one to omit terminating NUL
+                }
+                if (reader.BaseStream.Position + descriptionSize <= sectionEnd)
+                {
+                    Description = descriptionSize > 0 ? reader.ReadBytes(descriptionSize) : new byte[0];
                 }
             }
-            reader = null;
         }
         
         private int ReadSize()

--- a/ELFSharp/ELF/Sections/NoteSection.cs
+++ b/ELFSharp/ELF/Sections/NoteSection.cs
@@ -35,9 +35,9 @@ namespace ELFSharp.ELF.Sections
             }
         }
          
-        internal NoteSection(SectionHeader header, Class elfClass, Func<SimpleEndianessAwareReader> readerSource) : base(header, readerSource)
+        internal NoteSection(SectionHeader header, SimpleEndianessAwareReader reader) : base(header, reader)
         {
-            data = new NoteData(elfClass, header.Offset, header.Size, readerSource);
+            data = new NoteData(header.Offset, header.Size, reader);
         }
         
         private readonly NoteData data;

--- a/ELFSharp/ELF/Sections/ProgBitsSection.cs
+++ b/ELFSharp/ELF/Sections/ProgBitsSection.cs
@@ -5,26 +5,24 @@ namespace ELFSharp.ELF.Sections
 {
     public sealed class ProgBitsSection<T> : Section<T>, IProgBitsSection where T : struct
     {
-        internal ProgBitsSection(SectionHeader header, Func<SimpleEndianessAwareReader> readerSource) : base(header, readerSource)
+        internal ProgBitsSection(SectionHeader header, SimpleEndianessAwareReader reader) : base(header, reader)
         {
         }
         
 
         public void WriteContents(byte[] destination, int offset, int length = 0)
         {
-            using (var reader = ObtainReader())
+            SeekToSectionBeginning();
+            if (length == 0 || (ulong)length > Header.Size)
             {
-                if (length == 0 || (ulong)length > Header.Size)
-                {
-                    length = Convert.ToInt32(Header.Size);
-                }
-                var remaining = length;
-                while (remaining > 0)
-                {
-                    var buffer = reader.ReadBytes(Math.Min(BufferSize, remaining));
-                    buffer.CopyTo(destination, offset + (length - remaining));
-                    remaining -= buffer.Length;
-                }
+                length = Convert.ToInt32(Header.Size);
+            }
+            var remaining = length;
+            while (remaining > 0)
+            {
+                var buffer = Reader.ReadBytes(Math.Min(BufferSize, remaining));
+                buffer.CopyTo(destination, offset + (length - remaining));
+                remaining -= buffer.Length;
             }
         }
 

--- a/ELFSharp/ELF/Sections/Section.cs
+++ b/ELFSharp/ELF/Sections/Section.cs
@@ -6,25 +6,15 @@ namespace ELFSharp.ELF.Sections
 {
     public class Section<T> : ISection where T : struct
     {
-        internal Section(SectionHeader header, Func<SimpleEndianessAwareReader> readerSource)
+        internal Section(SectionHeader header, SimpleEndianessAwareReader reader)
         {
             Header = header;
-            this.readerSource = readerSource;
+            this.Reader = reader;
         }
 
         public virtual byte[] GetContents()
         {
-            using(var reader = ObtainReader())
-            {
-                return reader.ReadBytes(Convert.ToInt32(Header.Size));
-            }
-        }
-
-        protected SimpleEndianessAwareReader ObtainReader()
-        {
-            var reader = readerSource();
-            reader.BaseStream.Seek((long)Header.Offset, SeekOrigin.Begin);
-            return reader;
+            return Reader.ReadBytes(Convert.ToInt32(Header.Size));
         }
 
         public string Name
@@ -114,7 +104,12 @@ namespace ELFSharp.ELF.Sections
 
         internal SectionHeader Header { get; private set; }
 
-        private readonly Func<SimpleEndianessAwareReader> readerSource;
+        protected void SeekToSectionBeginning()
+        {
+            Reader.BaseStream.Seek((long)Header.Offset, SeekOrigin.Begin);
+        }
+
+        protected readonly SimpleEndianessAwareReader Reader;
     }
 }
 

--- a/ELFSharp/ELF/Sections/StringTable.cs
+++ b/ELFSharp/ELF/Sections/StringTable.cs
@@ -8,7 +8,7 @@ namespace ELFSharp.ELF.Sections
 {
     public sealed class StringTable<T> : Section<T>, IStringTable where T : struct
     {
-        internal StringTable(SectionHeader header, Func<SimpleEndianessAwareReader> readerSource) : base(header, readerSource)
+        internal StringTable(SectionHeader header, SimpleEndianessAwareReader reader) : base(header, reader)
         {
             stringCache = new Dictionary<long, string>
             {
@@ -76,12 +76,10 @@ namespace ELFSharp.ELF.Sections
 
         private byte[] ReadStringData()
         {
-            using(var reader = ObtainReader())
-            {
-                var blob = reader.ReadBytes((int)Header.Size);
-                Debug.Assert(blob.Length == 0 || (blob[0] == 0 && blob[blob.Length - 1] == 0), "First and last bytes must be the null character (except for empty string tables)");
-                return blob;
-            }
+            SeekToSectionBeginning();
+            var blob = Reader.ReadBytes((int)Header.Size);
+            Debug.Assert(blob.Length == 0 || (blob[0] == 0 && blob[blob.Length - 1] == 0), "First and last bytes must be the null character (except for empty string tables)");
+            return blob;
         }
 
         private readonly Dictionary<long, string> stringCache;

--- a/ELFSharp/ELF/Sections/SymbolTable.cs
+++ b/ELFSharp/ELF/Sections/SymbolTable.cs
@@ -8,7 +8,7 @@ namespace ELFSharp.ELF.Sections
 {
     public sealed class SymbolTable<T> : Section<T>, ISymbolTable where T : struct
     {
-        internal SymbolTable(SectionHeader header, Func<SimpleEndianessAwareReader> readerSource, IStringTable table, ELF<T> elf) : base(header, readerSource)
+        internal SymbolTable(SectionHeader header, SimpleEndianessAwareReader Reader, IStringTable table, ELF<T> elf) : base(header, Reader)
         {
             this.table = table;
             this.elf = elf;
@@ -27,33 +27,31 @@ namespace ELFSharp.ELF.Sections
 
         private void ReadSymbols()
         {
-            using(var reader = ObtainReader())
+            SeekToSectionBeginning();
+            entries = new List<SymbolEntry<T>>();
+            var adder = (ulong)(elf.Class == Class.Bit32 ? Consts.SymbolEntrySize32 : Consts.SymbolEntrySize64);
+            for(var i = 0UL; i < Header.Size; i += adder)
             {
-                entries = new List<SymbolEntry<T>>();
-                var adder = (ulong)(elf.Class == Class.Bit32 ? Consts.SymbolEntrySize32 : Consts.SymbolEntrySize64);
-                for(var i = 0UL; i < Header.Size; i += adder)
+                var value = 0UL;
+                var size = 0UL;
+                var nameIdx = Reader.ReadUInt32();
+                if(elf.Class == Class.Bit32)
                 {
-                    var value = 0UL;
-                    var size = 0UL;
-                    var nameIdx = reader.ReadUInt32();
-                    if(elf.Class == Class.Bit32)
-                    {
-                        value = reader.ReadUInt32();
-                        size = reader.ReadUInt32();
-                    }
-                    var info = reader.ReadByte();
-                    reader.ReadByte(); // other is read, which holds zero					
-                    var sectionIdx = reader.ReadUInt16();
-                    if(elf.Class == Class.Bit64)
-                    {
-                        value = reader.ReadUInt64();
-                        size = reader.ReadUInt64();
-                    }
-                    var name = table == null ? "<corrupt>" : table[nameIdx];
-                    var binding = (SymbolBinding)(info >> 4);
-                    var type = (SymbolType)(info & 0x0F);
-                    entries.Add(new SymbolEntry<T>(name, value.To<T>(), size.To<T>(), binding, type, elf, sectionIdx));
+                    value = Reader.ReadUInt32();
+                    size = Reader.ReadUInt32();
                 }
+                var info = Reader.ReadByte();
+                Reader.ReadByte(); // other is read, which holds zero					
+                var sectionIdx = Reader.ReadUInt16();
+                if(elf.Class == Class.Bit64)
+                {
+                    value = Reader.ReadUInt64();
+                    size = Reader.ReadUInt64();
+                }
+                var name = table == null ? "<corrupt>" : table[nameIdx];
+                var binding = (SymbolBinding)(info >> 4);
+                var type = (SymbolType)(info & 0x0F);
+                entries.Add(new SymbolEntry<T>(name, value.To<T>(), size.To<T>(), binding, type, elf, sectionIdx));
             }
         }
 

--- a/ELFSharp/ELF/Segments/Segment.cs
+++ b/ELFSharp/ELF/Segments/Segment.cs
@@ -6,9 +6,9 @@ namespace ELFSharp.ELF.Segments
 {
     public sealed class Segment<T> : ISegment
     {
-        internal Segment(long headerOffset, Class elfClass, Func<SimpleEndianessAwareReader> readerSource)
+        internal Segment(long headerOffset, Class elfClass, SimpleEndianessAwareReader reader)
         {            
-            this.readerSource = readerSource;			
+            this.reader = reader;			
             this.headerOffset = headerOffset;
             this.elfClass = elfClass;
             ReadHeader();
@@ -28,13 +28,7 @@ namespace ELFSharp.ELF.Segments
 
         public long FileSize { get; private set; }
 
-        public long Offset 
-        {
-            get 
-            {
-                return offset;
-            }
-        }
+        public long Offset { get; private set; }
 
         /// <summary>
         /// Returns content of the section as it is given in the file.
@@ -47,13 +41,12 @@ namespace ELFSharp.ELF.Segments
             {
                 return new byte[0];
             }
-            using(var reader = ObtainReader(offset))
-            {
-                var result = new byte[checked((int)FileSize)];
-                var fileImage = reader.ReadBytes(result.Length);
-                fileImage.CopyTo(result, 0);
-                return result;
-            }
+
+            SeekTo(Offset);
+            var result = new byte[checked((int)FileSize)];
+            var fileImage = reader.ReadBytes(result.Length);
+            fileImage.CopyTo(result, 0);
+            return result;
         }
 
         /// <summary>
@@ -68,21 +61,18 @@ namespace ELFSharp.ELF.Segments
             {
                 return new byte[0];
             }
-            using(var reader = ObtainReader(offset))
-            {
-                var result = new byte[sizeAsInt];
-                var fileImage = reader.ReadBytes(Math.Min(result.Length, checked((int)FileSize)));
-                fileImage.CopyTo(result, 0);
-                return result;
-            }
+
+            SeekTo(Offset);
+            var result = new byte[sizeAsInt];
+            var fileImage = reader.ReadBytes(Math.Min(result.Length, checked((int)FileSize)));
+            fileImage.CopyTo(result, 0);
+            return result; 
         }
 
         public byte[] GetRawHeader()
         {
-            using(var reader = ObtainReader(headerOffset))
-            {
-                return reader.ReadBytes(elfClass == Class.Bit32 ? 32 : 56);
-            }
+            SeekTo(headerOffset);
+            return reader.ReadBytes(elfClass == Class.Bit32 ? 32 : 56);
         }
 
         public override string ToString()
@@ -92,38 +82,34 @@ namespace ELFSharp.ELF.Segments
 
         private void ReadHeader()
         {
-            using(var reader = ObtainReader(headerOffset))
+            SeekTo(headerOffset);
+            Type = (SegmentType)reader.ReadUInt32();
+            if(elfClass == Class.Bit64)
             {
-                Type = (SegmentType)reader.ReadUInt32();
-                if(elfClass == Class.Bit64)
-                {
-                    Flags = (SegmentFlags)reader.ReadUInt32();
-                }
-                // TODO: some functions?s
-                offset = elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadInt64();
-                Address = (elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadUInt64()).To<T>();
-                PhysicalAddress = (elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadUInt64()).To<T>();
-                FileSize = elfClass == Class.Bit32 ? reader.ReadInt32() : reader.ReadInt64();
-                Size = (elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadUInt64()).To<T>();
-                if(elfClass == Class.Bit32)
-                {
-                    Flags = (SegmentFlags)reader.ReadUInt32();
-                }
-                Alignment = (elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadUInt64()).To<T>();
+                Flags = (SegmentFlags)reader.ReadUInt32();
             }
+            // TODO: some functions?s
+            Offset = elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadInt64();
+            Address = (elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadUInt64()).To<T>();
+            PhysicalAddress = (elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadUInt64()).To<T>();
+            FileSize = elfClass == Class.Bit32 ? reader.ReadInt32() : reader.ReadInt64();
+            Size = (elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadUInt64()).To<T>();
+            if(elfClass == Class.Bit32)
+            {
+                Flags = (SegmentFlags)reader.ReadUInt32();
+            }
+
+            Alignment = (elfClass == Class.Bit32 ? reader.ReadUInt32() : reader.ReadUInt64()).To<T>();
         }
 
-        private SimpleEndianessAwareReader ObtainReader(long givenOffset)
+        private void SeekTo(long givenOffset)
         {
-            var reader = readerSource();
             reader.BaseStream.Seek(givenOffset, SeekOrigin.Begin);
-            return reader;
         }
 
         private long headerOffset;
         private Class elfClass;
-        private long offset;
-        private Func<SimpleEndianessAwareReader> readerSource;
+        private SimpleEndianessAwareReader reader;
     }
 }
 

--- a/ELFSharp/ELFSharp.csproj
+++ b/ELFSharp/ELFSharp.csproj
@@ -4,19 +4,19 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sgKey.snk</AssemblyOriginatorKeyFile>
-    <InformationalVersion>2.3.0</InformationalVersion>
-    <PackageVersion>2.3.0</PackageVersion>
+    <InformationalVersion>2.4.0</InformationalVersion>
+    <PackageVersion>2.4.0</PackageVersion>
     <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox, Reuben Olinsky, Connor Christie</Authors>
     <Owners>Konrad Kruczyński</Owners>
     <PackageProjectUrl>http://elfsharp.turtleware.eu/</PackageProjectUrl>
-    <PackageReleaseNotes>Basic parsing for the .dynamic section.</PackageReleaseNotes>
+    <PackageReleaseNotes>ELFReader now offers overloads for reading streams directly, instead of files only.</PackageReleaseNotes>
     <Summary>C# library for reading binary ELF, UImage, Mach-O files</Summary>
     <PackageTags>ELF UImage Mach-O</PackageTags>
     <Title>ELFSharp</Title>
     <Description>C# library for reading binary ELF, UImage, Mach-O files</Description>
     <PackageId>ELFSharp</PackageId>
     <Version>2.0</Version>
-    <FileVersion>2.3.0.0</FileVersion>
+    <FileVersion>2.4.0.0</FileVersion>
     <PackageIconUrl>http://elfsharp.turtleware.eu/favicon.ico</PackageIconUrl>
   </PropertyGroup>
 </Project>

--- a/Tests/ELF/DynamicSectionTests.cs
+++ b/Tests/ELF/DynamicSectionTests.cs
@@ -15,7 +15,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldReadDynamicSection32()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
             var dynamicSection = (IDynamicSection)elf.GetSection(".dynamic");
             Assert.AreEqual(SectionType.Dynamic, dynamicSection.Type);
         }
@@ -23,7 +23,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldReadDynamicSection64()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
             var dynamicSection = (IDynamicSection)elf.GetSection(".dynamic");
             Assert.AreEqual(SectionType.Dynamic, dynamicSection.Type);
         }
@@ -31,7 +31,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldHaveCorrectDynamicEntryCount32()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
             var dynamicSection = (IDynamicSection)elf.GetSection(".dynamic");
             Assert.AreEqual(25, dynamicSection.Entries.Count());
         }
@@ -39,7 +39,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldHaveCorrectDynamicEntryCount64()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
             var dynamicSection = (IDynamicSection)elf.GetSection(".dynamic");
             Assert.AreEqual(29, dynamicSection.Entries.Count());
         }

--- a/Tests/ELF/NoteSectionTests.cs
+++ b/Tests/ELF/NoteSectionTests.cs
@@ -10,7 +10,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldReadNoteName32()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
             var noteSection = (INoteSection)elf.GetSection(".note.ABI-tag");
             Assert.AreEqual("GNU", noteSection.NoteName);
         }
@@ -18,7 +18,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldReadNoteName64()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
             var noteSection = (INoteSection)elf.GetSection(".note.ABI-tag");
             Assert.AreEqual("GNU", noteSection.NoteName);
         }
@@ -26,7 +26,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldReadNoteType32()
         {
-            var elf = ELFReader.Load<uint>(Utilities.GetBinary("hello32le"));
+            var elf = ELFReader.Load<uint>(Utilities.GetBinaryStream("hello32le"), true);
             var noteSection = (NoteSection<uint>)elf.GetSection(".note.ABI-tag");
             Assert.AreEqual(1, noteSection.NoteType);
         }
@@ -34,7 +34,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldReadNoteType64()
         {
-            var elf = ELFReader.Load<ulong>(Utilities.GetBinary("hello64le"));
+            var elf = ELFReader.Load<ulong>(Utilities.GetBinaryStream("hello64le"), true);
             var noteSection = (NoteSection<ulong>)elf.GetSection(".note.ABI-tag");
             Assert.AreEqual(1, noteSection.NoteType);
         }
@@ -47,7 +47,7 @@ namespace Tests.ELF
             // binary containing such a section and retrieve the note, all without
             // throwing an exception.
             const string sectionName = ".note.custom";
-            var elf = ELFReader.Load<uint>(Utilities.GetBinary("custom-note"));
+            var elf = ELFReader.Load<uint>(Utilities.GetBinaryStream("custom-note"), true);
             var noteSection = (NoteSection<uint>)elf.GetSection(sectionName);
             Assert.AreEqual(sectionName, noteSection.Name);
         }

--- a/Tests/ELF/OpeningTests.cs
+++ b/Tests/ELF/OpeningTests.cs
@@ -10,93 +10,93 @@ namespace Tests.ELF
         [Test]
         public void ShouldChooseGoodClass32()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
             Assert.AreEqual(Class.Bit32, elf.Class);
         }
         
         [Test]
         public void ShouldChooseGoodClass64()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
             Assert.AreEqual(Class.Bit64, elf.Class);
         }
         
         [Test]
         public void ShouldOpenHelloWorld32()
         {
-			ELFReader.Load(Utilities.GetBinary("hello32le"));
+			ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
         }
         
         [Test]
         public void ShouldOpenHelloWorld64()
         {           
-            ELFReader.Load(Utilities.GetBinary("hello64le"));
+            ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
         }
         
         [Test]
         public void ShouldProperlyParseClass32()
         {
-            var elf32 = ELFReader.Load<uint>(Utilities.GetBinary("hello32le"));
+            var elf32 = ELFReader.Load<uint>(Utilities.GetBinaryStream("hello32le"), true);
             Assert.AreEqual(Class.Bit32, elf32.Class);          
         }
 
         [Test]
         public void ShouldProperlyParseClass64()
         {           
-            var elf64 = ELFReader.Load<ulong>(Utilities.GetBinary("hello64le"));
+            var elf64 = ELFReader.Load<ulong>(Utilities.GetBinaryStream("hello64le"), true);
             Assert.AreEqual(Class.Bit64, elf64.Class);
         }
         
         [Test]
         public void ShouldProperlyParseEndianess()
         {
-			var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
-            Assert.AreEqual(Endianess.LittleEndian, elf.Endianess);
-			elf = ELFReader.Load(Utilities.GetBinary("vmlinuxOpenRisc"));
-            Assert.AreEqual(Endianess.BigEndian, elf.Endianess);
+			using var elfLittleEndian = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
+            Assert.AreEqual(Endianess.LittleEndian, elfLittleEndian.Endianess);
+			using var elfBigEndian = ELFReader.Load(Utilities.GetBinaryStream("vmlinuxOpenRisc"), true);
+            Assert.AreEqual(Endianess.BigEndian, elfBigEndian.Endianess);
         }
         
         [Test]
         public void ShouldOpenBigEndian()
         {
-            ELFReader.Load(Utilities.GetBinary("vmlinuxOpenRisc"));
+            ELFReader.Load(Utilities.GetBinaryStream("vmlinuxOpenRisc"), true);
         }
 
         [Test]
         public void GithubIssueNo2()
         {
-            ELFReader.Load(Utilities.GetBinary("mpuG890.axf"));
+            ELFReader.Load(Utilities.GetBinaryStream("mpuG890.axf"), true);
         }
 
 		[Test]
 		public void GithubIssueNo3()
 		{
-			ELFReader.Load(Utilities.GetBinary("issue3"));
+			ELFReader.Load(Utilities.GetBinaryStream("issue3"), true);
 		}
 
 		[Test]
 		public void ShouldNotOpenNonELFFile()
 		{
-            Assert.IsFalse(ELFReader.TryLoad(Utilities.GetBinary("notelf"), out var _));
+            Assert.IsFalse(ELFReader.TryLoad(Utilities.GetBinaryStream("notelf"), true, out var _));
         }
 
         [Test]
         public void GithubIssueNo9()
         {
-            ELFReader.Load(Utilities.GetBinary("stripped-all-binary"));
+            ELFReader.Load(Utilities.GetBinaryStream("stripped-all-binary"), true);
         }
 
         [Test]
         public void GithubIssueNo24()
         {
-            ELFReader.Load(Utilities.GetBinary("issue24.elf"));
+            ELFReader.Load(Utilities.GetBinaryStream("issue24.elf"), true);
         }
 
         // Github issue no 49
         [Test]
         public void ShouldOpenEmptyStringTableElf()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("libcoreclr"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("libcoreclr"), true);
             var section = elf.GetSection(".dynstr");
             Assert.AreEqual(SectionType.NoBits, section.Type);
         }

--- a/Tests/ELF/ProgBitsSectionTests.cs
+++ b/Tests/ELF/ProgBitsSectionTests.cs
@@ -11,7 +11,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldGetLoadAddress32()
         {
-            var elf = ELFReader.Load<uint>(Utilities.GetBinary("hello32le"));
+            var elf = ELFReader.Load<uint>(Utilities.GetBinaryStream("hello32le"), true);
             var sectionsToLoad = elf.GetSections<ProgBitsSection<uint>>().Where(x => x.LoadAddress != 0);
             Assert.AreEqual(13, sectionsToLoad.Count());
         }
@@ -19,7 +19,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldGetLoadAddress64()
         {
-            var elf = ELFReader.Load<ulong>(Utilities.GetBinary("hello64le"));
+            var elf = ELFReader.Load<ulong>(Utilities.GetBinaryStream("hello64le"), true);
             var sectionsToLoad = elf.GetSections<ProgBitsSection<ulong>>().Where(x => x.LoadAddress != 0);
             Assert.AreEqual(12, sectionsToLoad.Count());
         }

--- a/Tests/ELF/SectionGettingTests.cs
+++ b/Tests/ELF/SectionGettingTests.cs
@@ -11,7 +11,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldGetSection()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("issue3"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("issue3"), true);
             elf.GetSection(".rodata");
         }
 
@@ -19,14 +19,14 @@ namespace Tests.ELF
         public void ShouldHandleNonExistingSection()
         {
             ISection section;
-            Assert.IsFalse(ELFReader.Load(Utilities.GetBinary("issue3")).TryGetSection(".nonexisting", out section));
+            Assert.IsFalse(ELFReader.Load(Utilities.GetBinaryStream("issue3"), true).TryGetSection(".nonexisting", out section));
         }
 
         [Test]
         public void ShouldHandleOutOfRangeSection()
         {
             ISection section;
-            Assert.IsFalse(ELFReader.Load(Utilities.GetBinary("issue3")).TryGetSection(28, out section));
+            Assert.IsFalse(ELFReader.Load(Utilities.GetBinaryStream("issue3"), true).TryGetSection(28, out section));
         }
 
     }

--- a/Tests/ELF/SectionHeadersParsingTests.cs
+++ b/Tests/ELF/SectionHeadersParsingTests.cs
@@ -11,21 +11,21 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindProperNumberOfSections32()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
             Assert.AreEqual(29, elf.Sections.Count());
         }
         
         [Test]
         public void ShouldFindProperNumberOfSections64()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
             Assert.AreEqual(30, elf.Sections.Count());
         }
 
         [Test]
         public void ShouldFindProperAlignment32()
         {
-            var elf = ELFReader.Load<uint>(Utilities.GetBinary("hello32le"));
+            var elf = ELFReader.Load<uint>(Utilities.GetBinaryStream("hello32le"), true);
             var header = elf.Sections.First(x => x.Name == ".init");
             Assert.AreEqual(4, header.Alignment);
         }
@@ -33,7 +33,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindProperAlignment64()
         {
-            var elf = ELFReader.Load<ulong>(Utilities.GetBinary("hello64le"));
+            var elf = ELFReader.Load<ulong>(Utilities.GetBinaryStream("hello64le"), true);
             var header = elf.Sections.First(x => x.Name == ".text");
             Assert.AreEqual(16, header.Alignment);
         }
@@ -41,7 +41,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindProperEntrySize32()
         {
-            var elf = ELFReader.Load<uint>(Utilities.GetBinary("hello32le"));
+            var elf = ELFReader.Load<uint>(Utilities.GetBinaryStream("hello32le"), true);
             var header = elf.Sections.First(x => x.Name == ".dynsym");
             Assert.AreEqual(0x10, header.EntrySize);
         }
@@ -49,7 +49,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindProperEntrySize64()
         {
-            var elf = ELFReader.Load<ulong>(Utilities.GetBinary("hello64le"));
+            var elf = ELFReader.Load<ulong>(Utilities.GetBinaryStream("hello64le"), true);
             var header = elf.Sections.First(x => x.Name == ".dynsym");
             Assert.AreEqual(0x18, header.EntrySize);
         }
@@ -57,7 +57,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindAllNotes32()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
             var notes = elf.GetSections<INoteSection>();
             Assert.AreEqual(2, notes.Count());
         }
@@ -65,7 +65,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindAllNotes64()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
             var notes = elf.GetSections<INoteSection>();
             Assert.AreEqual(2, notes.Count());
         }
@@ -73,7 +73,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindProperOffset()
         {
-            var elf = ELFReader.Load<ulong>(Utilities.GetBinary("hello64le"));
+            var elf = ELFReader.Load<ulong>(Utilities.GetBinaryStream("hello64le"), true);
             var section = elf.Sections.First(x => x.Name == ".strtab");
             Assert.AreEqual(0x17A0, section.Offset);
         }

--- a/Tests/ELF/SegmentsTests.cs
+++ b/Tests/ELF/SegmentsTests.cs
@@ -11,21 +11,21 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindAllSegmentsH32LE()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
             Assert.AreEqual(8, elf.Segments.Count());
         }
         
         [Test]
         public void ShouldFindAllSegmentsOR32BE()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("vmlinuxOpenRisc"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("vmlinuxOpenRisc"), true);
             Assert.AreEqual(2, elf.Segments.Count());
         }
 
         [Test]
         public void ShouldFindProperFlags32()
         {
-            var elf = ELFReader.Load<uint>(Utilities.GetBinary("hello32le"));
+            var elf = ELFReader.Load<uint>(Utilities.GetBinaryStream("hello32le"), true);
             var segment = elf.Segments.First(x => x.Address == 0x08048034);
             Assert.IsTrue(segment.Flags.HasFlag(SegmentFlags.Execute));
             Assert.IsTrue(segment.Flags.HasFlag(SegmentFlags.Read));
@@ -35,7 +35,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindProperFlags64()
         {
-            var elf = ELFReader.Load<ulong>(Utilities.GetBinary("hello64le"));
+            var elf = ELFReader.Load<ulong>(Utilities.GetBinaryStream("hello64le"), true);
             var segment = elf.Segments.First(x => x.Address == 0x400000);
             Assert.IsTrue(segment.Flags.HasFlag(SegmentFlags.Execute));
             Assert.IsTrue(segment.Flags.HasFlag(SegmentFlags.Read));
@@ -45,7 +45,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindProperAlignment32()
         {
-            var elf = ELFReader.Load<uint>(Utilities.GetBinary("hello32le"));
+            var elf = ELFReader.Load<uint>(Utilities.GetBinaryStream("hello32le"), true);
             var segment = elf.Segments.First(x => x.Address == 0x08048000);
             Assert.AreEqual(0x1000, segment.Alignment);
         }
@@ -53,7 +53,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindProperAlignment64()
         {
-            var elf = ELFReader.Load<ulong>(Utilities.GetBinary("hello64le"));
+            var elf = ELFReader.Load<ulong>(Utilities.GetBinaryStream("hello64le"), true);
             var segment = elf.Segments.First(x => x.Address == 0x6006c8);
             Assert.AreEqual(8, segment.Alignment);
         }
@@ -61,7 +61,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldGetFileContents()
         {
-            var elf = ELFReader.Load<int>(Utilities.GetBinary("hello32le"));
+            var elf = ELFReader.Load<int>(Utilities.GetBinaryStream("hello32le"), true);
             var segment = elf.Segments.Single(x => x.Address == 0x8049F14 && x.Type == SegmentType.Load);
             Assert.AreEqual(256, segment.GetFileContents().Length);
         }
@@ -69,7 +69,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldGetMemoryContents()
         {
-            var elf = ELFReader.Load<int>(Utilities.GetBinary("hello32le"));
+            var elf = ELFReader.Load<int>(Utilities.GetBinaryStream("hello32le"), true);
             var segment = elf.Segments.Single(x => x.Address == 0x8049F14 && x.Type == SegmentType.Load);
             Assert.AreEqual(264, segment.GetMemoryContents().Length);
         }
@@ -77,7 +77,7 @@ namespace Tests.ELF
         [Test]
         public void GithubIssueNo45()
         {
-            var elf = ELFReader.Load<int>(Utilities.GetBinary("hello32le"));
+            var elf = ELFReader.Load<int>(Utilities.GetBinaryStream("hello32le"), true);
             var segment = elf.Segments.Single(x => x.Address == 0x8049F14 && x.Type == SegmentType.Load);
 
             byte[] memoryContents = segment.GetMemoryContents();

--- a/Tests/ELF/StringTableTests.cs
+++ b/Tests/ELF/StringTableTests.cs
@@ -10,7 +10,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindAllStrings()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
             Assert.IsTrue(elf.HasSectionsStringTable, 
                           "Sections string table was not found in 32 bit ELF.");
             Assert.AreEqual(29, elf.SectionsStringTable.Strings.Count());
@@ -19,7 +19,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindAllStrings64()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
             Assert.IsTrue(elf.HasSectionsStringTable, 
                           "Sections string table was not found in 64 bit ELF.");
             Assert.AreEqual(30, elf.SectionsStringTable.Strings.Count());
@@ -28,7 +28,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindAllStringsBigEndian()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("vmlinuxOpenRisc"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("vmlinuxOpenRisc"), true);
             Assert.IsTrue(
                 elf.HasSectionsStringTable,
                 "Sections string table was not found in 32 bit big endian ELF."

--- a/Tests/ELF/SymbolTableTests.cs
+++ b/Tests/ELF/SymbolTableTests.cs
@@ -11,7 +11,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindAllSymbols32()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("hello32le"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello32le"), true);
             var symtab = (ISymbolTable)elf.GetSection(".symtab");
             Assert.AreEqual(64, symtab.Entries.Count());            
         }
@@ -19,7 +19,7 @@ namespace Tests.ELF
         [Test]
         public void ShouldFindAllSymbols64()
         {
-			var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+			using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
 			var symtab = (ISymbolTable)elf.GetSection(".symtab");           
             Assert.AreEqual(64, symtab.Entries.Count());           
         }
@@ -27,7 +27,7 @@ namespace Tests.ELF
         [Test]
         public void GithubIssueNo24()
         {
-            var elf = ELFReader.Load(Utilities.GetBinary("issue24.elf"));
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("issue24.elf"), true);
             var dynamicSymbolSection = (SymbolTable<uint>)elf.GetSection(".dynsym");
             dynamicSymbolSection.Entries.Any(x => x.Name == "<corrupt>");
         }

--- a/Tests/ELF/WebTests.cs
+++ b/Tests/ELF/WebTests.cs
@@ -13,7 +13,7 @@ namespace Tests.ELF
 		[Test]
 		public void ListELFSectionHeaders()
 		{
-			var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+			using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
 			var output = new List<string>();
 
 			foreach(var header in elf.Sections)
@@ -57,7 +57,7 @@ namespace Tests.ELF
 		[Test]
 		public void GetNamesOfFunctionSymbols()
 		{
-			var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+			using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
 			var output = new List<string>();
 
 			var functions = ((ISymbolTable)elf.GetSection(".symtab")).Entries.Where(x => x.Type == SymbolType.Function);
@@ -85,7 +85,7 @@ _init";
 		[Test]
 		public void WriteAllLoadableProgBitsToArray()
 		{
-			var elf = ELFReader.Load(Utilities.GetBinary("hello64le"));
+			using var elf = ELFReader.Load(Utilities.GetBinaryStream("hello64le"), true);
 
 			var sectionsToLoad = elf.GetSections<ProgBitsSection<ulong>>()
 				.Where(x => x.LoadAddress != 0);

--- a/Tests/Utilities.cs
+++ b/Tests/Utilities.cs
@@ -8,17 +8,22 @@ namespace Tests
     [SetUpFixture]
 	public class Utilities
 	{
-		public static string GetBinary(string name)
+		public static Stream GetBinaryStream(string name)
 		{
+            return typeof(Utilities).Assembly.GetManifestResourceStream(ResourcesPrefix + name);
+        }
+
+        public static string GetBinary(string name)
+        {
             var fileName = Path.GetTempFileName();
             using(var fileStream = File.OpenWrite(fileName))
-            using(var resourceStream = typeof(Utilities).Assembly.GetManifestResourceStream(ResourcesPrefix + name))
+            using(var resourceStream = GetBinaryStream(name))
             {
                 resourceStream.CopyTo(fileStream);
             }
             TemporaryFiles.Add(fileName);
             return fileName;
-		}
+        }
 
         [OneTimeTearDown]
         public static void DeleteAllTemporaries()


### PR DESCRIPTION
ELF instances can now be created directly from Stream. Old, file
overloads are still there. Test utilities can be simplified once the
same work is done for Mach-O and UImage. Important refactoring and
simplication done at the same time.

This closes #56.