### PR TITLE
Fix Section.GetContents Method

### DIFF
--- a/ELFSharp/ELF/Sections/Section.cs
+++ b/ELFSharp/ELF/Sections/Section.cs
@@ -14,6 +14,7 @@ namespace ELFSharp.ELF.Sections
 
         public virtual byte[] GetContents()
         {
+            Reader.BaseStream.Seek((long)Header.Offset, SeekOrigin.Begin);
             return Reader.ReadBytes(Convert.ToInt32(Header.Size));
         }
 

--- a/ELFSharp/ELFSharp.csproj
+++ b/ELFSharp/ELFSharp.csproj
@@ -1,25 +1,25 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sgKey.snk</AssemblyOriginatorKeyFile>
-    <InformationalVersion>2.6.0</InformationalVersion>
-    <PackageVersion>2.6.0</PackageVersion>
-    <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox, Reuben Olinsky, Connor Christie</Authors>
+    <InformationalVersion>2.6.1</InformationalVersion>
+    <PackageVersion>2.6.1</PackageVersion>
+    <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox, Reuben Olinsky, Connor Christie, Rollrat</Authors>
     <Owners>Konrad Kruczyński</Owners>
     <PackageProjectUrl>http://elfsharp.turtleware.eu/</PackageProjectUrl>
-    <PackageReleaseNotes>ELFSharp library now targets only .NET Standard 2.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed a bug where the Socket.GetContents method could not fetch content normally.</PackageReleaseNotes>
     <Summary>C# library for reading binary ELF, UImage, Mach-O files</Summary>
     <PackageTags>ELF UImage Mach-O</PackageTags>
     <Title>ELFSharp</Title>
     <Description>C# library for reading binary ELF, UImage, Mach-O files</Description>
     <PackageId>ELFSharp</PackageId>
     <Version>2.0</Version>
-    <FileVersion>2.6.0.0</FileVersion>
+    <FileVersion>2.6.1.0</FileVersion>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath=""/>
+    <None Include="icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/README
+++ b/README
@@ -12,6 +12,7 @@ Other contributors (in the order of the first contribution)
 * Fox
 * Reuben Olinsky
 * Connor Christie
+* Rollrat
 
 You can find license in the LICENSE file.
 


### PR DESCRIPTION
`GetContents` function prints the wrong bytes.

``` cs
var elf = ELFReader.Load("test/1. Hello World/a.out", false);
var code = (ProgBitsSection<ulong>)elf.GetSection(".text");
var test1 = code.GetContents();

fs.Seek((long)code.Offset, SeekOrigin.Begin);
var test2 = new byte[999999];
fs.Read(test, 0, (int)code.Size);
```

`test1` and `test2` arrays are definitely different.