### PR TITLE
Fix macho64 Segment offset parsing error

### DIFF
--- a/ELFSharp/ELFSharp.csproj
+++ b/ELFSharp/ELFSharp.csproj
@@ -4,12 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sgKey.snk</AssemblyOriginatorKeyFile>
-    <Version>2.8.0.0</Version>
+    <Version>2.8.1.0</Version>
     <AssemblyVersion>2.0</AssemblyVersion>
-    <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox, Reuben Olinsky, Connor Christie, Rollrat</Authors>
+    <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox, Reuben Olinsky, Connor Christie, Rollrat, Ulysses Wu</Authors>
     <Owners>Konrad Kruczyński</Owners>
     <PackageProjectUrl>http://elfsharp.turtleware.eu/</PackageProjectUrl>
-    <PackageReleaseNotes>ELFSharp can now handle NOTE segment (program header).</PackageReleaseNotes>
+    <PackageReleaseNotes>Mach-O: 
+Fix Section Offset parsing issue (causing GetData() throw ArgumentOutOfRangeException).
+ELFSharp.MachO.Section: Type of `Address`, `Size` changed to `ulong`; Type of `Offset`, `AlignExponent` changed to `uint`.</PackageReleaseNotes>
     <Summary>C# library for reading binary ELF, UImage, Mach-O files</Summary>
     <PackageTags>ELF UImage Mach-O</PackageTags>
     <Title>ELFSharp</Title>

--- a/ELFSharp/MachO/Section.cs
+++ b/ELFSharp/MachO/Section.cs
@@ -19,7 +19,7 @@ namespace ELFSharp.MachO
         public string Name { get; private set; }
         public ulong Address { get; private set; }
         public ulong Size { get; private set; }
-        public ulong Offset { get; private set; }
+        public uint Offset { get; private set; }
         public uint AlignExponent { get; private set; }
 
         public byte[] GetData()

--- a/ELFSharp/MachO/Section.cs
+++ b/ELFSharp/MachO/Section.cs
@@ -1,32 +1,38 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace ELFSharp.MachO
 {
+    [DebuggerDisplay("Section({segment.Name,nq},{Name,nq})")]
     public sealed class Section
     {
-        public Section(string name, long address, long size, long offsetInSegment, int alignExponent, Segment segment)
+        public Section(string name, ulong address, ulong size, uint offset, uint alignExponent, Segment segment)
         {
             Name = name;
             Address = address;
             Size = size;
-            this.offsetInSegment = offsetInSegment;
+            Offset = offset;
             AlignExponent = alignExponent;
             this.segment = segment;
         }
 
         public string Name { get; private set; }
-        public long Address { get; private set; }
-        public long Size { get; private set; }
-        public int AlignExponent { get; private set; }
+        public ulong Address { get; private set; }
+        public ulong Size { get; private set; }
+        public ulong Offset { get; private set; }
+        public uint AlignExponent { get; private set; }
 
         public byte[] GetData()
         {
+            if (Offset < segment.FileOffset || Offset + Size > segment.FileOffset + segment.Size)
+            {
+                return new byte[0];
+            }
             var result = new byte[Size];
-            Array.Copy(segment.GetData(), offsetInSegment, result, 0, Size);
+            Array.Copy(segment.GetData(), (int)(Offset - segment.FileOffset), result, 0, (int)Size);
             return result;
         }
 
-        private readonly long offsetInSegment;
         private readonly Segment segment;
     }
 }

--- a/ELFSharp/MachO/Segment.cs
+++ b/ELFSharp/MachO/Segment.cs
@@ -44,13 +44,14 @@ namespace ELFSharp.MachO
                 }
                 var sectionAddress = ReadInt32OrInt64();
                 var sectionSize = ReadInt32OrInt64();
-                var offsetInSegment = ReadInt32OrInt64() - fileOffset;
+                var offsetInSegment = Reader.ReadInt32() - fileOffset;
                 if(offsetInSegment < 0)
                 {
                     throw new InvalidOperationException("Unexpected section offset lower than segment offset.");
                 }
                 var alignExponent = Reader.ReadInt32();
-                Reader.ReadBytes(20);
+                Reader.ReadBytes(is64 ? 24 : 20);
+
                 var section = new Section(sectionName, sectionAddress, sectionSize, offsetInSegment, alignExponent, this);
                 sections.Add(section);
             }

--- a/ELFSharp/MachO/Symbol.cs
+++ b/ELFSharp/MachO/Symbol.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace ELFSharp.MachO
 {
+    [DebuggerDisplay("Symbol({Name,nq},{Value})")]
     public struct Symbol
     {
         public Symbol(string name, long value) : this()

--- a/README
+++ b/README
@@ -13,6 +13,7 @@ Other contributors (in the order of the first contribution)
 * Reuben Olinsky
 * Connor Christie
 * Rollrat
+* Ulysses Wu
 
 You can find license in the LICENSE file.
 


### PR DESCRIPTION
```
struct section_64 {
        char            sectname[16];
        char            segname[16];
        uint64_t        addr;
        uint64_t        size;
        uint32_t        offset;
        uint32_t        align;
        uint32_t        reloff;
        uint32_t        nreloc;
        uint32_t        flags;
        uint32_t        reserved1;
        uint32_t        reserved2;
        uint32_t        reserved3;
};
```
offset is always 4 bytes. The unfixed version may cause exception when using `Section.GetData()`.

* Rename `offsetInSegment` to `Offset` since it should be. If the section Offset is out of Segment (usually happens on `__bss` or `__common` section), just return empty byte array instead of throw exception. Make Segment `FileOffset` `public` since `Section.GetData()` now uses it, and as a file format parsing lib, maybe it's better to make more info accessible.

* Change some members' type from `long` to `ulong` since `uint64_t` is equivalent to `ulong`. Change `ReadInt32OrInt64` method to UInt version.

* Add `[DebuggerDisplay]` Attribute for `Section`, `Segment`, `Symbol` to make debug more comfortable. You can also add it to Elf types if you like it.