### PR TITLE
Fix parsing error for loading Mach-O object file

### DIFF
--- a/ELFSharp/MachO/MachO.cs
+++ b/ELFSharp/MachO/MachO.cs
@@ -36,6 +36,8 @@ namespace ELFSharp.MachO
 
         public FileType FileType { get; private set; }
 
+        public bool Is64 => is64;
+
         private void ReadCommands(int noOfCommands, Stream stream, SimpleEndianessAwareReader reader)
         {
             for(var i = 0; i < noOfCommands; i++)
@@ -64,7 +66,7 @@ namespace ELFSharp.MachO
                     break;
                 case CommandType.Segment:
                 case CommandType.Segment64:
-                    commands[i] = new Segment(reader, stream, is64);
+                    commands[i] = new Segment(reader, stream, this);
                     break;
                 default:
                     reader.ReadBytes((int)commandSize - 8); // 8 bytes is the size of the common command header

--- a/ELFSharp/MachO/Section.cs
+++ b/ELFSharp/MachO/Section.cs
@@ -6,9 +6,10 @@ namespace ELFSharp.MachO
     [DebuggerDisplay("Section({segment.Name,nq},{Name,nq})")]
     public sealed class Section
     {
-        public Section(string name, ulong address, ulong size, uint offset, uint alignExponent, Segment segment)
+        public Section(string name, string segmentName, ulong address, ulong size, uint offset, uint alignExponent, Segment segment)
         {
             Name = name;
+            SegmentName = segmentName;
             Address = address;
             Size = size;
             Offset = offset;
@@ -17,6 +18,7 @@ namespace ELFSharp.MachO
         }
 
         public string Name { get; private set; }
+        public string SegmentName { get; private set; }
         public ulong Address { get; private set; }
         public ulong Size { get; private set; }
         public uint Offset { get; private set; }

--- a/ELFSharp/MachO/Section.cs
+++ b/ELFSharp/MachO/Section.cs
@@ -6,7 +6,7 @@ namespace ELFSharp.MachO
     [DebuggerDisplay("Section({segment.Name,nq},{Name,nq})")]
     public sealed class Section
     {
-        public Section(string name, string segmentName, ulong address, ulong size, uint offset, uint alignExponent, Segment segment)
+        public Section(string name, string segmentName, ulong address, ulong size, uint offset, uint alignExponent, uint relocOffset, uint numberOfReloc, uint flags, Segment segment)
         {
             Name = name;
             SegmentName = segmentName;
@@ -14,6 +14,9 @@ namespace ELFSharp.MachO
             Size = size;
             Offset = offset;
             AlignExponent = alignExponent;
+            RelocOffset = relocOffset;
+            RelocCount = numberOfReloc;
+            Flags = flags;
             this.segment = segment;
         }
 
@@ -23,6 +26,9 @@ namespace ELFSharp.MachO
         public ulong Size { get; private set; }
         public uint Offset { get; private set; }
         public uint AlignExponent { get; private set; }
+        public uint RelocOffset { get; private set; }
+        public uint RelocCount { get; private set; }
+        public uint Flags { get; private set; }
 
         public byte[] GetData()
         {

--- a/ELFSharp/MachO/Segment.cs
+++ b/ELFSharp/MachO/Segment.cs
@@ -12,9 +12,9 @@ namespace ELFSharp.MachO
     [DebuggerDisplay("{Type}({Name,nq})")]
     public sealed class Segment : Command
     {
-        public Segment(SimpleEndianessAwareReader reader, Stream stream, bool is64) : base(reader, stream)
+        public Segment(SimpleEndianessAwareReader reader, Stream stream, MachO machO) : base(reader, stream)
         {
-            this.is64 = is64;
+            this.is64 = machO.Is64;
             Name = ReadSectionOrSegmentName();
             Address = ReadUInt32OrUInt64();
             Size = ReadUInt32OrUInt64();
@@ -40,16 +40,20 @@ namespace ELFSharp.MachO
             {
                 var sectionName = ReadSectionOrSegmentName();
                 var segmentName = ReadSectionOrSegmentName();
-                if(segmentName != Name)
+
+                // An intermediate object file contains only one segment.
+                // This segment name is empty, its sections segment names are not empty.
+                if (machO.FileType != FileType.Object && segmentName != Name)
                 {
                     throw new InvalidOperationException("Unexpected name of the section's segment.");
                 }
+
                 var sectionAddress = ReadUInt32OrUInt64();
                 var sectionSize = ReadUInt32OrUInt64();
                 var offset = Reader.ReadUInt32();
                 var alignExponent = Reader.ReadUInt32();
                 Reader.ReadBytes(is64 ? 24 : 20);
-                var section = new Section(sectionName, sectionAddress, sectionSize, offset, alignExponent, this);
+                var section = new Section(sectionName, segmentName, sectionAddress, sectionSize, offset, alignExponent, this);
                 sections.Add(section);
             }
 

--- a/ELFSharp/MachO/Segment.cs
+++ b/ELFSharp/MachO/Segment.cs
@@ -52,8 +52,14 @@ namespace ELFSharp.MachO
                 var sectionSize = ReadUInt32OrUInt64();
                 var offset = Reader.ReadUInt32();
                 var alignExponent = Reader.ReadUInt32();
-                Reader.ReadBytes(is64 ? 24 : 20);
-                var section = new Section(sectionName, segmentName, sectionAddress, sectionSize, offset, alignExponent, this);
+                var relocOffset = Reader.ReadUInt32();
+                var numberOfReloc = Reader.ReadUInt32();
+                var flags = Reader.ReadUInt32();
+                _ = Reader.ReadUInt32(); // reserved1
+                _ = Reader.ReadUInt32(); // reserved2
+                _ = is64 ? Reader.ReadUInt32() : 0; // reserved3
+
+                var section = new Section(sectionName, segmentName, sectionAddress, sectionSize, offset, alignExponent, relocOffset, numberOfReloc, flags, this);
                 sections.Add(section);
             }
 

--- a/Tests/MachO/OpeningTests.cs
+++ b/Tests/MachO/OpeningTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using ELFSharp.MachO;
 using System;
+using System.Linq;
 
 namespace Tests.MachO
 {
@@ -63,6 +64,16 @@ namespace Tests.MachO
             var machOs = MachOReader.LoadFat(Utilities.GetBinaryStream("MachO-OSX-ppc-openssl-1.0.1h"), true);
             Assert.AreEqual(1, machOs.Count);
             Assert.AreEqual(Machine.PowerPc, machOs[0].Machine);
+        }
+
+        [Test]
+        public void ShouldOpenMachOObjectFile()
+        {
+            // intermediate object file has only 1 segement.
+            var result = MachOReader.TryLoad(Utilities.GetBinaryStream("simple-mach-o-object.o"), true, out ELFSharp.MachO.MachO machO);
+            Assert.AreEqual(MachOResult.OK, result);
+            Assert.AreEqual(machO.FileType, FileType.Object);
+            Assert.AreEqual(machO.GetCommandsOfType<Segment>().Count(), 1);
         }
     }
 }

--- a/Tests/MachO/OpeningTests.cs
+++ b/Tests/MachO/OpeningTests.cs
@@ -69,7 +69,7 @@ namespace Tests.MachO
         [Test]
         public void ShouldOpenMachOObjectFile()
         {
-            // intermediate object file has only 1 segement.
+            // intermediate object file has only 1 segment.
             var result = MachOReader.TryLoad(Utilities.GetBinaryStream("simple-mach-o-object.o"), true, out ELFSharp.MachO.MachO machO);
             Assert.AreEqual(MachOResult.OK, result);
             Assert.AreEqual(machO.FileType, FileType.Object);


### PR DESCRIPTION
Fix InvalidOperation error when parsing a Mach-O object file. Fix for #77 

According to this [article](https://github.com/aidansteele/osx-abi-macho-file-format-reference):
> For compactness, an intermediate object file contains only one segment. This segment has no name; it contains all the sections destined ultimately for different segments in the final object file. The data structure that defines a section contains the name of the segment the section is intended for, and the static linker places each section in the final object file accordingly.

For Mach-O object file I can see the only 1 segment name is empty and section names are set.
```
                SegName: __TEXT  | SecName: __text | Address: 0 | Size: 27 | Offset: 458 | Align: 0
                SegName: __TEXT  | SecName: __cstring | Address: 27 | Size: 1d | Offset: 47f | Align: 0
                SegName: __DWARF | SecName: __debug_frame | Address: 48 | Size: 48 | Offset: 4a0 | Align: 3
                SegName: __TEXT  | SecName: __eh_frame | Address: 90 | Size: 50 | Offset: 4e8 | Align: 3
                SegName: __DWARF | SecName: __debug_info | Address: e0 | Size: 1a1 | Offset: 538 | Align: 0
                SegName: __DWARF | SecName: __debug_abbrev | Address: 281 | Size: 7f | Offset: 6d9 | Align: 0
                SegName: __DWARF | SecName: __debug_pubnames | Address: 300 | Size: 27 | Offset: 758 | Align: 0
                SegName: __DWARF | SecName: __debug_pubtypes | Address: 327 | Size: cb | Offset: 77f | Align: 0
                SegName: __DWARF | SecName: __debug_aranges | Address: 3f2 | Size: 30 | Offset: 84a | Align: 0
                SegName: __DWARF | SecName: __debug_line | Address: 422 | Size: a7 | Offset: 87a | Align: 0
                SegName: __DWARF | SecName: __debug_str | Address: 4c9 | Size: 0 | Offset: 921 | Align: 0
```

Since binary files are not allowed to be checked-in, attached the binary file here which is used by test I added.
[simple-mach-o-object.zip](https://github.com/konrad-kruczynski/elfsharp/files/6600871/simple-mach-o-object.zip)

