### PR TITLE
Fixed Section.GetContents trying to read NoBits section

### DIFF
--- a/ELFSharp/ELF/Sections/Section.cs
+++ b/ELFSharp/ELF/Sections/Section.cs
@@ -14,6 +14,8 @@ namespace ELFSharp.ELF.Sections
 
         public virtual byte[] GetContents()
         {
+            if (Type == SectionType.NoBits)
+                return new byte[] {};
             Reader.BaseStream.Seek((long)Header.Offset, SeekOrigin.Begin);
             return Reader.ReadBytes(Convert.ToInt32(Header.Size));
         }

--- a/ELFSharp/ELF/Sections/Section.cs
+++ b/ELFSharp/ELF/Sections/Section.cs
@@ -15,7 +15,10 @@ namespace ELFSharp.ELF.Sections
         public virtual byte[] GetContents()
         {
             if (Type == SectionType.NoBits)
-                return new byte[] {};
+            {
+                return Array.Empty<byte>();
+            }
+            
             Reader.BaseStream.Seek((long)Header.Offset, SeekOrigin.Begin);
             return Reader.ReadBytes(Convert.ToInt32(Header.Size));
         }


### PR DESCRIPTION
https://man7.org/linux/man-pages/man5/elf.5.html

Search for SHT_NOBITS

> sh_offset
>  This member's value holds the byte offset from the
              beginning of the file to the first byte in the section.
              One section type, SHT_NOBITS, occupies **no space in the
              file**, and its sh_offset member locates the conceptual
              placement in the file.

The old code tried to happily read a section from file, that simply isn't present in the file, which causes this to return bogus data.
I'm not sure if this is the correct approach to fix this, but the section isn't present in the file thus you cannot really return its contents.

If you need a repro,

` objcopy --only-keep-debug sourceBinary sourceBinary.debug`
turns .eh_frame into NoBits