### PR TITLE
Add license expression for nuget package

### DIFF
--- a/ELFSharp/ELFSharp.csproj
+++ b/ELFSharp/ELFSharp.csproj
@@ -16,7 +16,7 @@
     <Description>C# library for reading binary ELF, UImage, Mach-O files</Description>
     <PackageId>ELFSharp</PackageId>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="" />


### PR DESCRIPTION
Fixes: https://github.com/konrad-kruczynski/elfsharp/issues/64

Context: https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
Context: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file
Context: https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#important-nuget-package-metadata
Context: https://spdx.org/licenses

Update `ELFSharp.csproj` to use `$(PackageLicenseExpression)` instead
of `$(PackageLicenseFile)`.  This makes it for certain automated
tools to "reason" about the license.