### PR TITLE
Fix shouldOwnStream argument of MachO instances

### DIFF
--- a/ELFSharp/MachO/MachO.cs
+++ b/ELFSharp/MachO/MachO.cs
@@ -11,7 +11,7 @@ namespace ELFSharp.MachO
         {
             this.is64 = is64;
 
-            using var reader = new SimpleEndianessAwareReader(stream, endianess, ownsStream);
+            using var reader = new SimpleEndianessAwareReader(stream, endianess, !ownsStream);
 
             Machine = (Machine)reader.ReadInt32();
             reader.ReadBytes(4); // we don't support the cpu subtype now

--- a/Tests/ELF/OpeningTests.cs
+++ b/Tests/ELF/OpeningTests.cs
@@ -105,6 +105,24 @@ namespace Tests.ELF
             var section = elf.GetSection(".dynstr");
             Assert.AreEqual(SectionType.NoBits, section.Type);
         }
+
+        [Test]
+        public void ShouldDisposeStream()
+        {
+            var isDisposed = false;
+            var stream = new StreamWrapper(Utilities.GetBinaryStream("hello32le"), () => isDisposed = true);
+            ELFReader.Load(stream, shouldOwnStream: true).Dispose();
+            Assert.True(isDisposed);
+        }
+
+        [Test]
+        public void ShouldNotDisposeStream()
+        {
+            var isDisposed = false;
+            var stream = new StreamWrapper(Utilities.GetBinaryStream("hello32le"), () => isDisposed = true);
+            ELFReader.Load(stream, shouldOwnStream: false).Dispose();
+            Assert.False(isDisposed);
+        }
     }
 }
 

--- a/Tests/MachO/OpeningTests.cs
+++ b/Tests/MachO/OpeningTests.cs
@@ -75,6 +75,24 @@ namespace Tests.MachO
             Assert.AreEqual(machO.FileType, FileType.Object);
             Assert.AreEqual(machO.GetCommandsOfType<Segment>().Count(), 1);
         }
+
+        [Test]
+        public void ShouldDisposeStream()
+        {
+            var isDisposed = false;
+            var stream = new StreamWrapper(Utilities.GetBinaryStream("simple-mach-o"), () => isDisposed = true);
+            MachOReader.Load(stream, shouldOwnStream: true);
+            Assert.True(isDisposed);
+        }
+
+        [Test]
+        public void ShouldNotDisposeStream()
+        {
+            var isDisposed = false;
+            var stream = new StreamWrapper(Utilities.GetBinaryStream("simple-mach-o"), () => isDisposed = true);
+            MachOReader.Load(stream, shouldOwnStream: false);
+            Assert.False(isDisposed);
+        }
     }
 }
 

--- a/Tests/StreamWrapper.cs
+++ b/Tests/StreamWrapper.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+
+namespace Tests
+{
+    public class StreamWrapper : Stream
+    {
+        private readonly Stream stream;
+        private readonly Action onDispose;
+
+        public StreamWrapper(Stream stream, Action onDispose)
+        {
+            this.stream = stream;
+            this.onDispose = onDispose;
+        }
+
+        public override void Flush() => stream.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => stream.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => stream.Seek(offset, origin);
+
+        public override void SetLength(long value) => stream.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => stream.Write(buffer, offset, count);
+
+        public override bool CanRead => stream.CanRead;
+
+        public override bool CanSeek => stream.CanSeek;
+
+        public override bool CanWrite => stream.CanWrite;
+
+        public override long Length => stream.Length;
+
+        public override long Position
+        {
+            get => stream.Position;
+            set => stream.Position = value;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            onDispose();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
In order to match expectations (and also the ELF behaviour)

* When shouldOwnStream is `true` the passed stream should be disposed.
* When shouldOwnStream is `false` the passed stream should __not__ be disposed.