### PR TITLE
Add `where T : Command` constraint on GetCommandsOfType<T>

### DIFF
--- a/ELFSharp/MachO/MachO.cs
+++ b/ELFSharp/MachO/MachO.cs
@@ -27,7 +27,7 @@ namespace ELFSharp.MachO
             ReadCommands(noOfCommands, stream, reader);
         }
 
-        public IEnumerable<T> GetCommandsOfType<T>()
+        public IEnumerable<T> GetCommandsOfType<T>() where T : Command
         {
             return commands.Where(x => x != null).OfType<T>();
         }


### PR DESCRIPTION
It doesn't make send to pass anything else but a `Command` as the generic type parameter of `GetCommandsOfType<T>`.