### PR TITLE
Support multiple NoteData within a NoteSegment

### DIFF
--- a/ELFSharp/ELF/Sections/NoteSection.cs
+++ b/ELFSharp/ELF/Sections/NoteSection.cs
@@ -18,7 +18,7 @@ namespace ELFSharp.ELF.Sections
         {
             get
             {
-                return data.Description;
+                return data.DescriptionBytes;
             }
         }
 

--- a/ELFSharp/ELF/Segments/INoteData.cs
+++ b/ELFSharp/ELF/Segments/INoteData.cs
@@ -1,0 +1,31 @@
+﻿using System.IO;
+
+namespace ELFSharp.ELF.Segments
+{
+    public interface INoteData
+    {
+        /// <summary>
+        /// Owner of the note. 
+        /// </summary>
+        string Name { get;}
+
+        /// <summary>
+        /// Data contents of the note. The format of this depends on the combination of the Name and Type properties and often
+        /// corresponds to a struct.
+        /// 
+        /// For example, see elf.h in the Linux kernel source tree.
+        /// </summary>
+        byte[] Description { get;}
+
+        /// <summary>
+        /// Data type
+        /// </summary>
+        ulong Type { get; }
+
+        /// <summary>
+        /// Returns the Description byte[] as a Stream
+        /// </summary>
+        /// <returns></returns>
+        Stream ToStream();
+    }
+}

--- a/ELFSharp/ELF/Segments/INoteData.cs
+++ b/ELFSharp/ELF/Segments/INoteData.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.ObjectModel;
+using System.IO;
 
 namespace ELFSharp.ELF.Segments
 {
@@ -7,7 +8,7 @@ namespace ELFSharp.ELF.Segments
         /// <summary>
         /// Owner of the note. 
         /// </summary>
-        string Name { get;}
+        string Name { get; }
 
         /// <summary>
         /// Data contents of the note. The format of this depends on the combination of the Name and Type properties and often
@@ -15,7 +16,7 @@ namespace ELFSharp.ELF.Segments
         /// 
         /// For example, see elf.h in the Linux kernel source tree.
         /// </summary>
-        byte[] Description { get;}
+        ReadOnlyCollection<byte> Description { get; }
 
         /// <summary>
         /// Data type

--- a/ELFSharp/ELF/Segments/INoteSegment.cs
+++ b/ELFSharp/ELF/Segments/INoteSegment.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+
 namespace ELFSharp.ELF.Segments
 {
     public interface INoteSegment : ISegment
@@ -6,5 +8,10 @@ namespace ELFSharp.ELF.Segments
         string NoteName { get; }
         ulong NoteType { get; }
         byte[] NoteDescription { get; }
+
+        /// <summary>
+        /// Returns all notes within the segment
+        /// </summary>
+        IReadOnlyList<INoteData> Notes { get; }
     }
 }

--- a/ELFSharp/ELF/Segments/NoteSegment.cs
+++ b/ELFSharp/ELF/Segments/NoteSegment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using ELFSharp.ELF.Sections;
 using ELFSharp.Utilities;
 
@@ -6,10 +7,43 @@ namespace ELFSharp.ELF.Segments
 {
     public sealed class NoteSegment<T> : Segment<T>, INoteSegment
     {
+        private List<NoteData> mNotes = new List<NoteData>();
+
         internal NoteSegment(long headerOffset, Class elfClass, SimpleEndianessAwareReader reader)
             : base(headerOffset, elfClass, reader)
         {
-            data = new NoteData((ulong)base.Offset, (ulong)base.FileSize, reader);
+            ulong offset = (ulong)base.Offset;
+            ulong fileSize = (ulong)base.FileSize;
+            ulong remainingSize = fileSize;
+
+            // Keep the first NoteData as a property for backwards compatibility
+            data = new NoteData(offset, remainingSize, reader);
+            mNotes.Add(data);
+
+            offset += data.NoteFileSize;
+
+            // Read all additional notes within the segment
+            // Multiple notes are common in ELF core files
+            if (data.NoteFileSize < remainingSize)
+            {
+                remainingSize -= data.NoteFileSize;
+
+                while (remainingSize > NoteData.NOTE_DATA_HEADER_SIZE)
+                {
+                    var note = new NoteData(offset, remainingSize, reader);
+                    mNotes.Add(note);
+                    offset += note.NoteFileSize;
+                    if (note.NoteFileSize < remainingSize)
+                    {
+                        remainingSize -= note.NoteFileSize;
+                    }
+                    else
+                    {
+                        // File is damaged
+                        break;
+                    }
+                }
+            }
         }
 
         public string NoteName => data.Name;
@@ -17,6 +51,8 @@ namespace ELFSharp.ELF.Segments
         public ulong NoteType => data.Type;
 
         public byte[] NoteDescription => data.Description;
+
+        public IReadOnlyList<INoteData> Notes { get => mNotes.AsReadOnly(); }
 
         private readonly NoteData data;
     }

--- a/Tests/ELF/NoteSectionTests.cs
+++ b/Tests/ELF/NoteSectionTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using ELFSharp.ELF.Sections;
 using ELFSharp.ELF;
 using System.Linq;
+using ELFSharp.ELF.Segments;
 
 namespace Tests.ELF
 {
@@ -51,6 +52,33 @@ namespace Tests.ELF
             var elf = ELFReader.Load<uint>(Utilities.GetBinaryStream("custom-note"), true);
             var noteSection = (NoteSection<uint>)elf.GetSection(sectionName);
             Assert.AreEqual(sectionName, noteSection.Name);
+        }
+
+
+        [Test]
+        public void ShouldReadMultipleNotesWithinNoteSection()
+        {
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("elf32-core-adbd_3124"), true);
+            var noteSegment = elf.Segments.Where(x => x.Type == SegmentType.Note).First() as INoteSegment;
+            Assert.AreEqual(22, noteSegment.Notes.Count);
+        }
+
+        [Test]
+        public void ShouldReadMultipleNoteDataName()
+        {
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("elf32-core-adbd_3124"), true);
+            var noteSegment = elf.Segments.Where(x => x.Type == SegmentType.Note).First() as INoteSegment;
+            Assert.AreEqual("CORE", noteSegment.Notes[0].Name);
+            Assert.AreEqual("LINUX", noteSegment.Notes[6].Name);
+        }
+
+        [Test]
+        public void ShouldReadMultipleNoteDataType()
+        {
+            using var elf = ELFReader.Load(Utilities.GetBinaryStream("elf32-core-adbd_3124"), true);
+            var noteSegment = elf.Segments.Where(x => x.Type == SegmentType.Note).First() as INoteSegment;
+            Assert.AreEqual(1ul, noteSegment.Notes[0].Type);
+            Assert.AreEqual(1024ul, noteSegment.Notes[6].Type);
         }
     }
 }


### PR DESCRIPTION
**Added support for multiple NoteData within a single NoteSegment, as is common in ELF core dumps:**

- Added support for parsing multiple NodeData in NoteSegment and storing them in a List 
- Added INodeData interface to expose NodeData from a INoteSegment to package users
- Updated INodeSegment with a 'Nodes' property returning IReadOnlyList<INoteData> containing all the NoteData