### PR TITLE
Added a command to parse LC_UUID and ability to get the UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17] - 2023-04-03
+### Added
+- MachO: Added a command to parse LC_UUID and ability to get the UUID
+
 ## [2.16.1] - 2023-01-11
 ### Fixed
 - ELF: `ELFReader.TryLoad` now closes the underlying stream if it owns it and loading fails.

--- a/ELFSharp/ELFSharp.csproj
+++ b/ELFSharp/ELFSharp.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sgKey.snk</AssemblyOriginatorKeyFile>
-    <Version>2.16.1.0</Version>
+    <Version>2.17.0.0</Version>
     <AssemblyVersion>2.0</AssemblyVersion>
-    <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox, Reuben Olinsky, Connor Christie, Rollrat, Ulysses Wu, Cédric Luthi, Yong Yan, Filip Navara, Dedmen Miller, Murat Ocaktürk</Authors>
+    <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox, Reuben Olinsky, Connor Christie, Rollrat, Ulysses Wu, Cédric Luthi, Yong Yan, Filip Navara, Dedmen Miller, Murat Ocaktürk, Grivus</Authors>
     <Owners>Konrad Kruczyński</Owners>
     <PackageProjectUrl>http://elfsharp.it/</PackageProjectUrl>
     <PackageReleaseNotes>Fixed not closing underlying ELF stream on load fail. Detailed changelog available at: https://github.com/konrad-kruczynski/elfsharp/blob/master/CHANGELOG.md</PackageReleaseNotes>

--- a/ELFSharp/MachO/CommandType.cs
+++ b/ELFSharp/MachO/CommandType.cs
@@ -9,7 +9,8 @@
         LoadWeakDylib = 0x80000018u,
         Segment64 = 0x19,
         ReexportDylib = 0x8000001fu,
-        Main = 0x80000028u
+        Main = 0x80000028u,
+        UUID = 0x1b,
     }
 }
 

--- a/ELFSharp/MachO/MachO.cs
+++ b/ELFSharp/MachO/MachO.cs
@@ -70,6 +70,9 @@ namespace ELFSharp.MachO
                 case CommandType.Segment64:
                     commands[i] = new Segment(reader, stream, this);
                     break;
+                case CommandType.UUID:
+                    commands[i] = new UUID(reader, stream);
+                    break;
                 default:
                     reader.ReadBytes((int)commandSize - 8); // 8 bytes is the size of the common command header
                     break;

--- a/ELFSharp/MachO/UUID.cs
+++ b/ELFSharp/MachO/UUID.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using ELFSharp.Utilities;
+
+namespace ELFSharp.MachO
+{
+	public class UUID : Command
+	{
+        internal UUID(SimpleEndianessAwareReader reader, Stream stream) : base(reader, stream)
+        {
+            ID = ReadUUID();
+        }
+
+        public Guid ID { get; }
+
+        private Guid ReadUUID()
+        {
+            var rawBytes = Reader.ReadBytes(16).TakeWhile(x => x != 0).ToArray();
+
+            // Deal here with UUID endianess. Switch scheme is 4(r)-2(r)-2(r)-8(o)
+            // where r is reverse, o is original order.
+            Array.Reverse(rawBytes, 0, 4);
+            Array.Reverse(rawBytes, 4, 2);
+            Array.Reverse(rawBytes, 6, 2);
+
+            var guid = new Guid(rawBytes);
+            return guid;
+        }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Contributors (in the order of the first contribution)
 * Dedmen Miller
 * Jerker Olofsson
 * Murat Ocaktürk
+* Grivus
 
 ## License
 You can find license in the LICENSE file.

--- a/Tests/MachO/UUIDTests.cs
+++ b/Tests/MachO/UUIDTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NUnit.Framework;
+using ELFSharp.MachO;
+using System.IO;
+using System.Linq;
+
+namespace Tests.MachO
+{
+    [TestFixture]
+    public class UUIDTests
+	{
+        [Test]
+        public void ReadsUUID()
+        {
+            var archs = MachOReader.LoadFat(Utilities.GetBinaryStream("3dengine_libretro_ios.dylib"), true);
+
+            foreach(var arch in archs)
+            {
+                var ids = arch.GetCommandsOfType<UUID>();
+
+                // a valid macho can't have 0 LC_UUIDs 
+                Assert.AreNotEqual(ids.Count(), 0);
+
+                foreach(var id in ids)
+                {
+                    // for each arch the uuid must be specified
+                    Assert.AreNotEqual(id.ID, null);
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
I've added an ability to parse UUID load command from machO file. 
Also added a test, however I can't really run it on mac, because it can't find resources Tests Binaries files (submodule is actual).
I've checked it across real files by their full paths, but kept the original style in code. 