### PR TITLE
Fix large string table index

### DIFF
--- a/ELFSharp/ELF/ELF.cs
+++ b/ELFSharp/ELF/ELF.cs
@@ -288,7 +288,7 @@ namespace ELFSharp.ELF
                 return;
             }
 
-            var header = ReadSectionHeader(stringTableIndex);
+            var header = ReadSectionHeader(checked((int)stringTableIndex));
             if(header.Type != SectionType.StringTable)
             {
                 throw new InvalidOperationException("Given index of section header does not point at string table which was expected.");
@@ -369,6 +369,14 @@ namespace ELFSharp.ELF
             {
                 var firstSectionHeader = ReadSectionHeader(0, true);
                 sectionHeaderEntryCount = checked((uint)firstSectionHeader.Size);
+
+                // If the index of the string table is larger than or equal to SHN_LORESERVE (0xff00), this member holds SHN_XINDEX (0xffff)
+                // and the real index of the section name string table section is held in the sh_link member of the initial entry in section 
+                // header table. Otherwise, the sh_link member of the initial entry in section header table contains the value zero.
+                if (stringTableIndex == 0xffff)
+                {
+                    stringTableIndex = checked((uint)firstSectionHeader.Link);
+                }
             }
         }
 
@@ -419,7 +427,7 @@ namespace ELFSharp.ELF
         private ushort segmentHeaderEntryCount;
         private ushort sectionHeaderEntrySize;
         private uint sectionHeaderEntryCount;
-        private ushort stringTableIndex;
+        private uint stringTableIndex;
         private List<Segment<T>> segments;
         private List<Section<T>> sections;
         private Dictionary<string, int> sectionIndicesByName;

--- a/Tests/ELF/SectionHeadersParsingTests.cs
+++ b/Tests/ELF/SectionHeadersParsingTests.cs
@@ -77,6 +77,14 @@ namespace Tests.ELF
             var section = elf.Sections.First(x => x.Name == ".strtab");
             Assert.AreEqual(0x17A0, section.Offset);
         }
+
+        [Test]
+        public void ShouldFindSizeInFirstEntry()
+        {
+            var elf = ELFReader.Load<ulong>(Utilities.GetBinaryStream("large-elf.o"), true);
+            Assert.AreEqual(68302, elf.Sections.Count());
+            Assert.AreEqual(0x10ace, elf.Sections[0].Size);
+        }
     }
 }
 


### PR DESCRIPTION
Hi Konrad,

This fix is very much related to the change introduced in https://github.com/konrad-kruczynski/elfsharp/issues/89

The PR addresses an edge case best described in elf(5) — Linux manual page:
```
e_shstrndx
              If the index of section name string table section is
              larger than or equal to SHN_LORESERVE (0xff00), this
              member holds SHN_XINDEX (0xffff) and the real index of the
              section name string table section is held in the sh_link
              member of the initial entry in section header table.
              Otherwise, the sh_link member of the initial entry in
              section header table contains the value zero.
```

The problem would manifest itself in the following error message:

_System.InvalidOperationException : Given index of section header does not point at string table which was expected.
Stack Trace:
at ELFSharp.ELF.ELF'1.ReadStringTable() in /opt/elfsharp/ELFSharp/ELF/ELF.cs
at ELFSharp.ELF.ELF'1..ctor(Stream stream, Boolean ownsStream) in /opt/elfsharp/ELFSharp/ELF/ELF.cs
at ELFSharp.ELF.ELFReader.Load[T](Stream stream, Boolean shouldOwnStream) in /opt/elfsharp/ELFSharp/ELF/ELFReader.cs_

The solution is very similar, essentially checking if the value of `stringTableIndex` is **SHN_XINDEX** and, if true, assign the real value from `firstSectionHeader.Link`

I'm also adding a test binary in a separate PR into https://github.com/konrad-kruczynski/elfsharp-test-binaries/pull/3 that would catch this problem. Feel free to integrate the changes yourself if you find this dual PR approach is too messy.

Cheers,
Alex.