### PR TITLE
Read exact 16 bytes in UUID load command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.2] - 2023-06-09
+### Fixed
+- MachO: fix for reading LC_UUID command.
+
 ## [2.17.1] - 2023-04-25
 ### Fixed
 - ELF: fix for `SHN_LORESERVE` edge case. 

--- a/ELFSharp/ELFSharp.csproj
+++ b/ELFSharp/ELFSharp.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sgKey.snk</AssemblyOriginatorKeyFile>
-    <Version>2.17.1.0</Version>
+    <Version>2.17.2.0</Version>
     <AssemblyVersion>2.0</AssemblyVersion>
     <Authors>Konrad Kruczyński, Piotr Zierhoffer, Łukasz Kucharski, Bastian Eicher, Cameron, Everett Maus, Fox, Reuben Olinsky, Connor Christie, Rollrat, Ulysses Wu, Cédric Luthi, Yong Yan, Filip Navara, Dedmen Miller, Murat Ocaktürk, Grivus, Alex E.</Authors>
     <Owners>Konrad Kruczyński</Owners>

--- a/ELFSharp/MachO/UUID.cs
+++ b/ELFSharp/MachO/UUID.cs
@@ -19,7 +19,7 @@ namespace ELFSharp.MachO
 
         private Guid ReadUUID()
         {
-            var rawBytes = Reader.ReadBytes(16).TakeWhile(x => x != 0).ToArray();
+            var rawBytes = Reader.ReadBytes(16).ToArray();
 
             // Deal here with UUID endianess. Switch scheme is 4(r)-2(r)-2(r)-8(o)
             // where r is reverse, o is original order.


### PR DESCRIPTION
Here is a small fix to the UUID load command parsing: we need to read exact 16 bytes, not limited by 0 byte (in contrast to reading a string)