### PR TITLE
MachO: Fix a typo in x64 BE magic number

### DIFF
--- a/ELFSharp/MachO/MachOReader.cs
+++ b/ELFSharp/MachO/MachOReader.cs
@@ -84,7 +84,7 @@ namespace ELFSharp.MachO
             { 0xFEEDFACE, (false, Endianess.LittleEndian) },
             { 0xFEEDFACF, (true, Endianess.LittleEndian) },
             { 0xCEFAEDFE, (false, Endianess.BigEndian) },
-            { 0xCFFEEDFE, (true, Endianess.BigEndian) }
+            { 0xCFFAEDFE, (true, Endianess.BigEndian) }
         };
 
         private const uint FatMagic = 0xBEBAFECA;


### PR DESCRIPTION
For x64 Big Endian architectures `0xcffaedfe` is a magic number, according to the official Apple Mach-O loader.

See https://opensource.apple.com/source/xnu/xnu-2050.18.24/EXTERNAL_HEADERS/mach-o/loader.h